### PR TITLE
Handling multiple modes and languages in word dictionary page

### DIFF
--- a/backend/service-word/src/main/scala/pl/smtc/smartwords/controller/DictionaryController.scala
+++ b/backend/service-word/src/main/scala/pl/smtc/smartwords/controller/DictionaryController.scala
@@ -13,7 +13,7 @@ class DictionaryController(wordDB: WordDatabase) {
     val service: DictionaryService = new DictionaryService(wordDB)
     val dsl = Http4sDsl[IO]; import dsl._
     HttpRoutes.of[IO] {
-      case GET -> Root => service.getDictionariesInfo()
+      case GET -> Root => service.getDictionaries
     }
   }
 }

--- a/backend/service-word/src/main/scala/pl/smtc/smartwords/controller/DictionaryController.scala
+++ b/backend/service-word/src/main/scala/pl/smtc/smartwords/controller/DictionaryController.scala
@@ -4,7 +4,6 @@ import cats.effect.IO
 import org.http4s.HttpRoutes
 import org.http4s.dsl.Http4sDsl
 import pl.smtc.smartwords.database._
-import pl.smtc.smartwords.model._
 import pl.smtc.smartwords.service._
 
 class DictionaryController(wordDB: WordDatabase) {

--- a/backend/service-word/src/main/scala/pl/smtc/smartwords/controller/DictionaryController.scala
+++ b/backend/service-word/src/main/scala/pl/smtc/smartwords/controller/DictionaryController.scala
@@ -9,6 +9,12 @@ import pl.smtc.smartwords.service._
 
 class DictionaryController(wordDB: WordDatabase) {
 
+  /**
+   * Routes (request -> response) for dictionaries endpoints/resources
+   * <ul>
+   *  <li>Receive all used dictionary data: <u>GET</u> /dictionaries -> OK 200+JSON | ERR 500</li>
+   * </ul>
+   */
   def getRoutes: HttpRoutes[IO] = {
     val service: DictionaryService = new DictionaryService(wordDB)
     val dsl = Http4sDsl[IO]; import dsl._

--- a/backend/service-word/src/main/scala/pl/smtc/smartwords/dao/DictionaryDao.scala
+++ b/backend/service-word/src/main/scala/pl/smtc/smartwords/dao/DictionaryDao.scala
@@ -6,6 +6,10 @@ import pl.smtc.smartwords.model._
 
 object DictionaryDao {
 
+  /**
+   * Method used to receive dictionary encoder (to JSON)
+   * @return dictionary object encoder
+   */
   def getDictionaryEncoder: Encoder[Dictionary] = Encoder.instance {
     (dict: Dictionary) => json"""{"game": ${dict.game},
                                   "mode": ${dict.mode},

--- a/backend/service-word/src/main/scala/pl/smtc/smartwords/dao/DictionaryDao.scala
+++ b/backend/service-word/src/main/scala/pl/smtc/smartwords/dao/DictionaryDao.scala
@@ -7,6 +7,20 @@ import pl.smtc.smartwords.model._
 object DictionaryDao {
 
   /**
+   * Method used to receive dictionary decoder (from JSON)
+   * @return dictionary object decoder
+   */
+  def getWordDecoder: Decoder[Dictionary] = Decoder.instance {
+    (input: HCursor) => for {
+      game <- input.downField("game").as[String]
+      mode <- input.downField("mode").as[Int]
+      language <- input.downField("language").as[String]
+    } yield {
+      Dictionary.create(Some(mode), language)
+    }
+  }
+
+  /**
    * Method used to receive dictionary encoder (to JSON)
    * @return dictionary object encoder
    */

--- a/backend/service-word/src/main/scala/pl/smtc/smartwords/dao/DictionaryDao.scala
+++ b/backend/service-word/src/main/scala/pl/smtc/smartwords/dao/DictionaryDao.scala
@@ -1,0 +1,15 @@
+package pl.smtc.smartwords.dao
+
+import io.circe._
+import io.circe.literal._
+import pl.smtc.smartwords.model._
+
+object DictionaryDao {
+
+  def getDictionaryEncoder: Encoder[Dictionary] = Encoder.instance {
+    (dict: Dictionary) => json"""{"game": ${dict.game},
+                                  "mode": ${dict.mode},
+                                  "language": ${dict.language}}"""
+  }
+
+}

--- a/backend/service-word/src/main/scala/pl/smtc/smartwords/model/Dictionary.scala
+++ b/backend/service-word/src/main/scala/pl/smtc/smartwords/model/Dictionary.scala
@@ -1,5 +1,7 @@
 package pl.smtc.smartwords.model
 
+import io.circe._
+import io.circe.literal._
 import pl.smtc.smartwords.utilities.DataParser
 
 import java.time.LocalDate
@@ -12,7 +14,16 @@ import java.time.format.DateTimeFormatter
  * @param mode identifier related to the game for which this word should be used
  * @param language language of the word
  */
-case class Dictionary(var file: String, game: String, mode: Option[Int], language: String)
+case class Dictionary(var file: String, game: String, mode: Option[Int], language: String) {
+
+  def toJson: Json = {
+    json"""{
+          "game": ${this.game},
+          "mode": ${this.mode},
+          "language": ${this.language}
+        }"""
+  }
+}
 
 object Dictionary {
   /**

--- a/backend/service-word/src/main/scala/pl/smtc/smartwords/model/Dictionary.scala
+++ b/backend/service-word/src/main/scala/pl/smtc/smartwords/model/Dictionary.scala
@@ -1,7 +1,5 @@
 package pl.smtc.smartwords.model
 
-import io.circe._
-import io.circe.literal._
 import pl.smtc.smartwords.utilities.DataParser
 
 import java.time.LocalDate
@@ -14,16 +12,7 @@ import java.time.format.DateTimeFormatter
  * @param mode identifier related to the game for which this word should be used
  * @param language language of the word
  */
-case class Dictionary(var file: String, game: String, mode: Option[Int], language: String) {
-
-  def toJson: Json = {
-    json"""{
-          "game": ${this.game},
-          "mode": ${this.mode},
-          "language": ${this.language}
-        }"""
-  }
-}
+case class Dictionary(var file: String, game: String, mode: Option[Int], language: String)
 
 object Dictionary {
   /**

--- a/backend/service-word/src/main/scala/pl/smtc/smartwords/service/DictionaryService.scala
+++ b/backend/service-word/src/main/scala/pl/smtc/smartwords/service/DictionaryService.scala
@@ -12,7 +12,7 @@ import pl.smtc.smartwords.model._
 
 class DictionaryService(wordDB: WordDatabase) {
 
-  def getDictionariesInfo(): IO[Response[IO]] = {
+  def getDictionaries: IO[Response[IO]] = {
     val availableDictionaries: Set[Dictionary] = wordDB.getWords.groupBy((word: Word) => word.dictionary).keySet
     val rawJson: Set[Json] = availableDictionaries.map(d => toJson(d))
     Ok(rawJson.asJson)

--- a/backend/service-word/src/main/scala/pl/smtc/smartwords/service/DictionaryService.scala
+++ b/backend/service-word/src/main/scala/pl/smtc/smartwords/service/DictionaryService.scala
@@ -1,19 +1,15 @@
 package pl.smtc.smartwords.service
 
 import cats.effect._
-import io.circe._
 import io.circe.syntax._
 import org.http4s._
 import org.http4s.circe._
 import org.http4s.dsl.io._
 import pl.smtc.smartwords.database._
-import pl.smtc.smartwords.model._
 
 class DictionaryService(wordDB: WordDatabase) {
 
   def getDictionaries: IO[Response[IO]] = {
-    val availableDictionaries: Set[Dictionary] = wordDB.getWords.groupBy((word: Word) => word.dictionary).keySet
-    val rawJson: Set[Json] = availableDictionaries.map(d => d.toJson)
-    Ok(rawJson.asJson)
+    Ok(wordDB.getWords.groupBy(_.dictionary).keySet.map(_.toJson).asJson)
   }
 }

--- a/backend/service-word/src/main/scala/pl/smtc/smartwords/service/DictionaryService.scala
+++ b/backend/service-word/src/main/scala/pl/smtc/smartwords/service/DictionaryService.scala
@@ -1,15 +1,20 @@
 package pl.smtc.smartwords.service
 
 import cats.effect._
+import io.circe._
 import io.circe.syntax._
 import org.http4s._
 import org.http4s.circe._
 import org.http4s.dsl.io._
+import pl.smtc.smartwords.dao._
 import pl.smtc.smartwords.database._
+import pl.smtc.smartwords.model._
 
 class DictionaryService(wordDB: WordDatabase) {
 
+  implicit val DictionaryEncoder: Encoder[Dictionary] = DictionaryDao.getDictionaryEncoder
+
   def getDictionaries: IO[Response[IO]] = {
-    Ok(wordDB.getWords.groupBy(_.dictionary).keySet.map(_.toJson).asJson)
+    Ok(wordDB.getWords.groupBy(_.dictionary).keySet.asJson)
   }
 }

--- a/backend/service-word/src/main/scala/pl/smtc/smartwords/service/DictionaryService.scala
+++ b/backend/service-word/src/main/scala/pl/smtc/smartwords/service/DictionaryService.scala
@@ -14,6 +14,10 @@ class DictionaryService(wordDB: WordDatabase) {
 
   implicit val DictionaryEncoder: Encoder[Dictionary] = DictionaryDao.getDictionaryEncoder
 
+  /**
+   * Method used to receive used dictionary data
+   * @return response with all used dictionaries
+   */
   def getDictionaries: IO[Response[IO]] = {
     Ok(wordDB.getWords.groupBy(_.dictionary).keySet.asJson)
   }

--- a/backend/service-word/src/main/scala/pl/smtc/smartwords/service/DictionaryService.scala
+++ b/backend/service-word/src/main/scala/pl/smtc/smartwords/service/DictionaryService.scala
@@ -2,7 +2,6 @@ package pl.smtc.smartwords.service
 
 import cats.effect._
 import io.circe._
-import io.circe.literal._
 import io.circe.syntax._
 import org.http4s._
 import org.http4s.circe._
@@ -14,15 +13,7 @@ class DictionaryService(wordDB: WordDatabase) {
 
   def getDictionaries: IO[Response[IO]] = {
     val availableDictionaries: Set[Dictionary] = wordDB.getWords.groupBy((word: Word) => word.dictionary).keySet
-    val rawJson: Set[Json] = availableDictionaries.map(d => toJson(d))
+    val rawJson: Set[Json] = availableDictionaries.map(d => d.toJson)
     Ok(rawJson.asJson)
-  }
-
-  private def toJson(dictionary: Dictionary): Json = {
-    json"""{
-          "game": ${dictionary.game},
-          "mode": ${dictionary.mode},
-          "language": ${dictionary.language}
-        }"""
   }
 }

--- a/frontend/css/words.css
+++ b/frontend/css/words.css
@@ -274,6 +274,7 @@ tr a.btn-edit {
   color: transparent;
   padding: 10px 15px;
   cursor: pointer;
+  margin: 0px 2px;
 }
 
 tr a.btn-edit:hover {
@@ -288,6 +289,7 @@ tr a.btn-delete {
   color: transparent;
   padding: 10px 5px;
   cursor: pointer;
+  margin: 0px 2px;
 }
 
 tr a.btn-delete:hover {

--- a/frontend/css/words.css
+++ b/frontend/css/words.css
@@ -197,11 +197,8 @@
 }
 
 #table-words td {
-  height: 100%;
-  line-height: 45px;
-  display: inline-block;
-  vertical-align: middle;
-  text-align: left;
+  display: flex;
+  align-items: center;
 }
 
 #table-words tbody tr {
@@ -246,7 +243,7 @@
 #table-words th:nth-child(2) {
   flex-basis: 20%;
   flex-grow: 1;
-  text-align: center;
+  justify-content: center;
 }
 
 #table-words td:nth-child(3),

--- a/frontend/css/words.css
+++ b/frontend/css/words.css
@@ -98,6 +98,15 @@
 
 #dictionary-selector select {
   width: 125px;
+  height: 25px;
+  border-color: black;
+  border-radius: 0;
+  font-size: 14px;
+  font-family: var(--clear-font-primary), var(--clear-font-backup), Verdana, sans-serif;
+}
+
+#dictionary-selector select:disabled {
+  border-color: gray;
 }
 
 #table-container {

--- a/frontend/css/words.css
+++ b/frontend/css/words.css
@@ -219,6 +219,7 @@
   background-color: whitesmoke;
   height: 30vh;
   text-align: center;
+  animation: overlay-text-opacity 0.65s ease-in;
 }
 
 #table-words tbody tr#no-words-row.row-visible {

--- a/frontend/css/words.css
+++ b/frontend/css/words.css
@@ -315,7 +315,7 @@ tr a.btn-delete:hover {
 
 @keyframes add-word-background {
   from {
-    background: url(../images/add.png) no-repeat
+    background: url(../images/add.png) no-repeat;
   }
   to {
     background: url(../images/add-disabled.png) no-repeat;
@@ -324,7 +324,7 @@ tr a.btn-delete:hover {
 
 @-webkit-keyframes add-word-background {
   from {
-    background: url(../images/add.png) no-repeat
+    background: url(../images/add.png) no-repeat;
   }
   to {
     background: url(../images/add-disabled.png) no-repeat;

--- a/frontend/css/words.css
+++ b/frontend/css/words.css
@@ -230,7 +230,7 @@
   text-align: center;
 }
 
-#table-words tbody td#no-words-text {
+#table-words tbody td#no-words-content {
   font-family: var(--styled-font), cursive;
   font-size: 20px;
   line-height: 30px;

--- a/frontend/css/words.css
+++ b/frontend/css/words.css
@@ -210,6 +210,14 @@
   align-items: center;
 }
 
+#table-words td#no-words-content {
+  height: 100%;
+  line-height: 45px;
+  display: inline-block;
+  vertical-align: middle;
+  text-align: left;
+}
+
 #table-words tbody tr {
   display: flex;
   padding: 3px 10px;

--- a/frontend/js/quiz-api.js
+++ b/frontend/js/quiz-api.js
@@ -1,4 +1,5 @@
 const URL = "http://localhost:2222/";
+const REQUEST_TIMEOUT = 15_000;
 
 /**
  * Method used to send a request to the quiz service to start a new quiz
@@ -20,6 +21,7 @@ const postQuizStart = (questionsNo, modeId, language, callback) => {
     }
   });
   postRequest.open("POST", URL + "quiz/start?size=" + questionsNo + "&lang=" + language + "&mode=" + modeId);
+  postRequest.timeout = REQUEST_TIMEOUT;
   postRequest.send();
 };
 
@@ -42,6 +44,7 @@ const getQuestionNo = (quizID, questionNo, callback) => {
     }
   });
   getRequest.open("GET", URL + "quiz/" + quizID + "/question/" + questionNo);
+  getRequest.timeout = REQUEST_TIMEOUT;
   getRequest.send();
 };
 
@@ -65,6 +68,7 @@ const postQuestionAnswer = (quizID, questionNo, answerNo, callback) => {
     }
   });
   postRequest.open("POST", URL + "quiz/" + quizID + "/question/" + questionNo + "/" + answerNo);
+  postRequest.timeout = REQUEST_TIMEOUT;
   postRequest.send();
 };
 
@@ -86,6 +90,7 @@ const getQuizStop = (quizID, callback) => {
     }
   });
   getRequest.open("GET", URL + "quiz/" + quizID + "/stop");
+  getRequest.timeout = REQUEST_TIMEOUT;
   getRequest.send();
 };
 
@@ -106,6 +111,7 @@ const getQuizStop = (quizID, callback) => {
     }
   });
   getRequest.open("GET", URL + "modes");
+  getRequest.timeout = REQUEST_TIMEOUT;
   getRequest.send();
 };
 

--- a/frontend/js/words-api.js
+++ b/frontend/js/words-api.js
@@ -6,7 +6,7 @@ const URL = "http://localhost:1111/";
  * @param {Function} callback function to be invoked when request is completed.
  *                            It should contain 2 parameters: error object and data object.
  */
-const getWords = (callback) => {
+const getWords = (mode, language, callback) => {
   const getRequest = new XMLHttpRequest();
   getRequest.addEventListener("readystatechange", () => {
     if (getRequest.DONE !== getRequest.readyState) return;
@@ -28,7 +28,7 @@ const getWords = (callback) => {
  * @param {Function} callback function to be invoked when request is completed.
  *                            It should contain 2 parameters: error object and data object.
  */
-const postWord = (newWordObject, callback) => {
+const postWord = (newWordObject, mode, language, callback) => {
   const postRequest = new XMLHttpRequest();
   postRequest.addEventListener("readystatechange", () => {
     if (postRequest.DONE !== postRequest.readyState) return;
@@ -52,7 +52,7 @@ const postWord = (newWordObject, callback) => {
  * @param {Function} callback function to be invoked when request is completed.
  *                            It should contain 2 parameters: error object and data object.
  */
-const putWord = (currWord, newWordObject, callback) => {
+const putWord = (currWord, newWordObject, mode, language, callback) => {
   const putRequest = new XMLHttpRequest();
   putRequest.addEventListener("readystatechange", () => {
     if (putRequest.DONE !== putRequest.readyState) return;
@@ -75,7 +75,7 @@ const putWord = (currWord, newWordObject, callback) => {
  * @param {Function} callback function to be invoked when request is completed.
  *                            It should contain 2 parameters: error object and data object.
  */
-const deleteWord = (wordName, callback) => {
+const deleteWord = (wordName, mode, language, callback) => {
   const deleteRequest = new XMLHttpRequest();
   deleteRequest.addEventListener("readystatechange", () => {
     if (deleteRequest.DONE !== deleteRequest.readyState) return;

--- a/frontend/js/words-api.js
+++ b/frontend/js/words-api.js
@@ -3,12 +3,13 @@ const URL = "http://localhost:1111/";
 /**
  * Method used to receive all words from smart-words service
  *
- * @param {Integer} mode of the specific game for which we want to receive words
- * @param {String} language name for which we want to receive words
+ * @param {String} game type of the game for which we want to receive words
+ * @param {String} mode specific game mode for which we want to receive words
+ * @param {String} language type of language for which we want to receive words
  * @param {Function} callback function to be invoked when request is completed.
  *                            It should contain 2 parameters: error object and data object.
  */
-const getWords = (mode, language, callback) => {
+const getWords = (game, mode, language, callback) => {
   const getRequest = new XMLHttpRequest();
   getRequest.addEventListener("readystatechange", () => {
     if (getRequest.DONE !== getRequest.readyState) return;

--- a/frontend/js/words-api.js
+++ b/frontend/js/words-api.js
@@ -92,6 +92,21 @@ const deleteWord = (wordName, callback) => {
   deleteRequest.send();
 };
 
+const getDictionaries = (callback) => {
+  const getRequest = new XMLHttpRequest();
+  getRequest.addEventListener("readystatechange", () => {
+    if (getRequest.DONE !== getRequest.readyState) return;
+    if (getRequest.status === 200) {
+      callback(undefined, JSON.parse(getRequest.responseText));
+    } else {
+      details = 0 === getRequest.status ? " - service unavailable" : " - " + getRequest.responseText;
+      callback(createErrorObject("cannot get dictionaries " + details, getRequest.status), undefined);
+    }
+  });
+  getRequest.open("GET", URL + "dictionaries");
+  getRequest.send();
+};
+
 /**
  * Method used to create error object from message and response status
  *

--- a/frontend/js/words-api.js
+++ b/frontend/js/words-api.js
@@ -90,6 +90,12 @@ const deleteWord = (wordName, mode, language, callback) => {
   deleteRequest.send();
 };
 
+/**
+ * Method used to receive used words dictionaries
+ *
+ * @param {Function} callback function to be invoked when request is completed.
+ *                            It should contain 2 parameters: error object and data object.
+ */
 const getDictionaries = (callback) => {
   const getRequest = new XMLHttpRequest();
   getRequest.addEventListener("readystatechange", () => {

--- a/frontend/js/words-api.js
+++ b/frontend/js/words-api.js
@@ -1,6 +1,4 @@
 const URL = "http://localhost:1111/";
-const mode = "0";
-const language = "pl";
 
 /**
  * Method used to receive all words from smart-words service

--- a/frontend/js/words-api.js
+++ b/frontend/js/words-api.js
@@ -1,4 +1,5 @@
 const URL = "http://localhost:1111/";
+const REQUEST_TIMEOUT = 15_000;
 
 /**
  * Method used to receive all words from smart-words service
@@ -21,6 +22,7 @@ const getWords = (game, mode, language, callback) => {
     }
   });
   getRequest.open("GET", URL + "words/" + mode + "/" + language);
+  getRequest.timeout = REQUEST_TIMEOUT;
   getRequest.send();
 };
 
@@ -45,6 +47,7 @@ const postWord = (newWordObject, mode, language, callback) => {
     }
   });
   postRequest.open("POST", URL + "words/" + mode + "/" + language);
+  postRequest.timeout = REQUEST_TIMEOUT;
   postRequest.setRequestHeader("Content-Type", "application/json;charset=UTF-8");
   postRequest.send(JSON.stringify(newWordObject));
 };
@@ -71,6 +74,7 @@ const putWord = (currWord, newWordObject, mode, language, callback) => {
     }
   });
   putRequest.open("PUT", URL + "words/" + mode + "/" + language + "/" + currWord);
+  putRequest.timeout = REQUEST_TIMEOUT;
   putRequest.setRequestHeader("Content-Type", "application/json;charset=UTF-8");
   putRequest.send(JSON.stringify(newWordObject));
 };
@@ -96,6 +100,7 @@ const deleteWord = (wordName, mode, language, callback) => {
     }
   });
   deleteRequest.open("DELETE", URL + "words/" + mode + "/" + language + "/" + wordName);
+  deleteRequest.timeout = REQUEST_TIMEOUT;
   deleteRequest.send();
 };
 
@@ -117,6 +122,7 @@ const getDictionaries = (callback) => {
     }
   });
   getRequest.open("GET", URL + "dictionaries");
+  getRequest.timeout = REQUEST_TIMEOUT;
   getRequest.send();
 };
 

--- a/frontend/js/words-api.js
+++ b/frontend/js/words-api.js
@@ -3,6 +3,8 @@ const URL = "http://localhost:1111/";
 /**
  * Method used to receive all words from smart-words service
  *
+ * @param {Integer} mode of the specific game for which we want to receive words
+ * @param {String} language name for which we want to receive words
  * @param {Function} callback function to be invoked when request is completed.
  *                            It should contain 2 parameters: error object and data object.
  */
@@ -25,6 +27,8 @@ const getWords = (mode, language, callback) => {
  * Method used to add new word to smart-words service
  *
  * @param {Object} newWordObject new word to be added to service
+ * @param {Integer} mode of the specific game for which we want to add new word
+ * @param {String} language name for which we want to add the new word
  * @param {Function} callback function to be invoked when request is completed.
  *                            It should contain 2 parameters: error object and data object.
  */
@@ -49,6 +53,8 @@ const postWord = (newWordObject, mode, language, callback) => {
  *
  * @param {String} currWord object name to be updated
  * @param {Object} newWordObject new word object values to be used and updated in service
+ * @param {Integer} mode of the specific game for which we want to update selected word
+ * @param {String} language name for which we want to update selected word
  * @param {Function} callback function to be invoked when request is completed.
  *                            It should contain 2 parameters: error object and data object.
  */
@@ -72,6 +78,8 @@ const putWord = (currWord, newWordObject, mode, language, callback) => {
  * Method used to remove specified word in smart-words service
  *
  * @param {String} wordName object name to be removed
+ * @param {Integer} mode of the specific game for which we want to delete selected word
+ * @param {String} language name for which we want to delete selected word
  * @param {Function} callback function to be invoked when request is completed.
  *                            It should contain 2 parameters: error object and data object.
  */

--- a/frontend/js/words-dictionary.js
+++ b/frontend/js/words-dictionary.js
@@ -33,6 +33,7 @@ function fillSelector(type, values) {
 
 function gameChanged() {
   let gameSelector = document.getElementById(`dictionary-selector-game`);
+  fillSelector("mode", Object.keys(availableDictionaries[gameSelector.value]));
   let modeSelector = document.getElementById(`dictionary-selector-mode`);
   modeSelector.disabled = gameSelector.value === "";
 }

--- a/frontend/js/words-dictionary.js
+++ b/frontend/js/words-dictionary.js
@@ -62,7 +62,7 @@ function initAvailableDictionaries(data) {
  * @param {String} type of specificied select element (supported values are: 'game', 'mode', and 'language')
  * @param {Array} values to be displayed as options is specified select element
  */
-function fillSelector(type, values) {
+function fillSelector(type, values, disabled) {
   let selector = document.getElementById(`dictionary-selector-${type}`);
   if (selector === null) {
     console.log(`Cannot find a dictionary selector element for ${type}...`);
@@ -72,6 +72,7 @@ function fillSelector(type, values) {
   let optionsHtml = defaultSelectorOption
   values.forEach((value) => optionsHtml += `<option value="${value}">${value}</option>`);
   selector.innerHTML = optionsHtml;
+  selector.disabled = disabled;
 }
 
 /**

--- a/frontend/js/words-dictionary.js
+++ b/frontend/js/words-dictionary.js
@@ -1,6 +1,16 @@
 var selectedMode = "0";
 var selectedLanguage = "pl";
 
+function fillDictionarySelectors() {
+  getDictionaries((err, data) => {
+    if (err) {
+      console.log("ERROR " + err.status + ": " + err.message);
+    } else {
+      console.log(data);
+    }
+  });
+}
+
 function gameChanged() {
     console.log("Game changed");
 }

--- a/frontend/js/words-dictionary.js
+++ b/frontend/js/words-dictionary.js
@@ -18,7 +18,7 @@ function fillDictionarySelectors() {
     } else {
       loadDictionariesUpdateUI(STATE_WORDS_OK);
       initAvailableDictionaries(Object.values(data));
-      fillSelector("game", Object.keys(availableDictionaries));
+      fillSelector("game", Object.keys(availableDictionaries), false);
       initSelectorsValues();
     }
   });
@@ -85,8 +85,7 @@ function gameChanged() {
     return;
   }
   selectedGame = gameSelector.value;
-  fillSelector("mode", Object.keys(availableDictionaries[selectedGame]));
-  modeSelector.disabled = selectedGame === "";
+  fillSelector("mode", Object.keys(availableDictionaries[selectedGame]), selectedGame === "");
 }
 
 /**
@@ -99,8 +98,7 @@ function modeChanged() {
     return;
   }
   selectedMode = modeSelector.value;
-  fillSelector("language", availableDictionaries[selectedGame][selectedMode]);
-  langSelector.disabled = selectedMode === "";
+  fillSelector("language", availableDictionaries[selectedGame][selectedMode], selectedMode === "");
 }
 
 /**

--- a/frontend/js/words-dictionary.js
+++ b/frontend/js/words-dictionary.js
@@ -49,6 +49,8 @@ function modeChanged() {
 }
 
 function languageChanged() {
+  let langSelector = document.getElementById(`dictionary-selector-language`);
+  selectedLanguage = langSelector.value;
   loadWords();
 }
 

--- a/frontend/js/words-dictionary.js
+++ b/frontend/js/words-dictionary.js
@@ -1,7 +1,6 @@
 var selectedGame = "quiz";
 var selectedMode = "0";
 var selectedLanguage = "pl";
-
 var availableDictionaries = {};
 
 function fillDictionarySelectors() {

--- a/frontend/js/words-dictionary.js
+++ b/frontend/js/words-dictionary.js
@@ -1,0 +1,2 @@
+var selectedMode = "0";
+var selectedLanguage = "pl";

--- a/frontend/js/words-dictionary.js
+++ b/frontend/js/words-dictionary.js
@@ -31,7 +31,9 @@ function fillSelector(type, values) {
 }
 
 function gameChanged() {
-  console.log("Game changed");
+  let gameSelector = document.getElementById(`dictionary-selector-game`);
+  let modeSelector = document.getElementById(`dictionary-selector-mode`);
+  modeSelector.disabled = gameSelector.value === "";
 }
 
 function modeChanged() {

--- a/frontend/js/words-dictionary.js
+++ b/frontend/js/words-dictionary.js
@@ -22,12 +22,12 @@ function fillDictionarySelectors() {
 }
 
 function fillSelector(type, values) {
-    let selector = document.getElementById(`dictionary-selector-${type}`);
-    let optionsHtml = `<option value="" default selected hidden>select ${type}</option>`;
-    values.forEach(value => {
-        optionsHtml += `<option value="${value}">${value}</option>`;
-    })
-    selector.innerHTML = optionsHtml;
+  let selector = document.getElementById(`dictionary-selector-${type}`);
+  let optionsHtml = `<option value="" default selected hidden>select ${type}</option>`;
+  values.forEach((value) => {
+    optionsHtml += `<option value="${value}">${value}</option>`;
+  });
+  selector.innerHTML = optionsHtml;
 }
 
 function gameChanged() {

--- a/frontend/js/words-dictionary.js
+++ b/frontend/js/words-dictionary.js
@@ -14,6 +14,18 @@ function fillDictionarySelectors() {
   });
 }
 
+function initSelectorsValues() {
+  let gameSelector = document.getElementById(`dictionary-selector-game`);
+  gameSelector.value = selectedGame;
+  gameSelector.dispatchEvent(new Event('change'))
+  let modeSelector = document.getElementById(`dictionary-selector-mode`);
+  modeSelector.value = selectedMode;
+  modeSelector.dispatchEvent(new Event('change'))
+  let langSelector = document.getElementById(`dictionary-selector-language`);
+  langSelector.value = selectedLanguage;
+  langSelector.dispatchEvent(new Event('change'))
+}
+
 function initAvailableDictionaries(data) {
   data.forEach((dict) => {
     if (!availableDictionaries[dict.game]) {

--- a/frontend/js/words-dictionary.js
+++ b/frontend/js/words-dictionary.js
@@ -1,8 +1,7 @@
 var selectedMode = "0";
 var selectedLanguage = "pl";
-var availableGames = new Set();
-var availableModes = new Set();
-var availableLangs = new Set();
+
+var availableDictionaries = {};
 
 function fillDictionarySelectors() {
   getDictionaries((err, data) => {
@@ -10,9 +9,13 @@ function fillDictionarySelectors() {
       console.log("ERROR " + err.status + ": " + err.message);
     } else {
       Object.values(data).forEach((dictionary) => {
-        availableGames.add(dictionary.game);
-        availableModes.add(dictionary.mode);
-        availableLangs.add(dictionary.language);
+        if (!availableDictionaries[dictionary.game]) {
+          availableDictionaries[dictionary.game] = {};
+        }
+        if (!availableDictionaries[dictionary.game][dictionary.mode]) {
+          availableDictionaries[dictionary.game][dictionary.mode] = [];
+        }
+        availableDictionaries[dictionary.game][dictionary.mode].push(dictionary.language);
       });
       fillSelector("game", Array.from(availableGames.values()));
       fillSelector("mode", Array.from(availableModes.values()));

--- a/frontend/js/words-dictionary.js
+++ b/frontend/js/words-dictionary.js
@@ -1,3 +1,4 @@
+var selectedGame = "quiz";
 var selectedMode = "0";
 var selectedLanguage = "pl";
 
@@ -33,9 +34,10 @@ function fillSelector(type, values) {
 
 function gameChanged() {
   let gameSelector = document.getElementById(`dictionary-selector-game`);
-  fillSelector("mode", Object.keys(availableDictionaries[gameSelector.value]));
+  selectedGame = gameSelector.value;
+  fillSelector("mode", Object.keys(availableDictionaries[selectedGame]));
   let modeSelector = document.getElementById(`dictionary-selector-mode`);
-  modeSelector.disabled = gameSelector.value === "";
+  modeSelector.disabled = selectedGame === "";
 }
 
 function modeChanged() {

--- a/frontend/js/words-dictionary.js
+++ b/frontend/js/words-dictionary.js
@@ -37,7 +37,9 @@ function gameChanged() {
 }
 
 function modeChanged() {
-  console.log("Mode changed");
+  let modeSelector = document.getElementById(`dictionary-selector-mode`);
+  let langSelector = document.getElementById(`dictionary-selector-language`);
+  langSelector.disabled = modeSelector.value === "";
 }
 
 function languageChanged() {

--- a/frontend/js/words-dictionary.js
+++ b/frontend/js/words-dictionary.js
@@ -1,2 +1,14 @@
 var selectedMode = "0";
 var selectedLanguage = "pl";
+
+function gameChanged() {
+    console.log("Game changed");
+}
+
+function modeChanged() {
+    console.log("Mode changed");
+}
+
+function languageChanged() {
+    console.log("Language changed");
+}

--- a/frontend/js/words-dictionary.js
+++ b/frontend/js/words-dictionary.js
@@ -61,6 +61,7 @@ function initAvailableDictionaries(data) {
  *
  * @param {String} type of specificied select element (supported values are: 'game', 'mode', and 'language')
  * @param {Array} values to be displayed as options is specified select element
+ * @param {Boolean} disabled if the filled select element should be grayed out (true), or not (false)
  */
 function fillSelector(type, values, disabled) {
   let selector = document.getElementById(`dictionary-selector-${type}`);

--- a/frontend/js/words-dictionary.js
+++ b/frontend/js/words-dictionary.js
@@ -6,6 +6,9 @@ var selectedGame = "quiz";
 var selectedMode = "0";
 var selectedLanguage = "pl";
 
+/**
+ * Method used to fill dictionary selectors (especially the starting one: game selector)
+ */
 function fillDictionarySelectors() {
   getDictionaries((err, data) => {
     if (err) {
@@ -18,6 +21,9 @@ function fillDictionarySelectors() {
   });
 }
 
+/**
+ * Method used to initialize all selectors with starting values
+ */
 function initSelectorsValues() {
   let gameSelector = document.getElementById(`dictionary-selector-game`);
   gameSelector.value = selectedGame;
@@ -30,6 +36,11 @@ function initSelectorsValues() {
   langSelector.dispatchEvent(new Event('change'))
 }
 
+/**
+ * Method used to initialize available dictionaries container with received data
+ *
+ * @param {Object} data received from word service with needed dictionaries information
+ */
 function initAvailableDictionaries(data) {
   data.forEach((dict) => {
     if (!availableDictionaries[dict.game]) {
@@ -42,6 +53,12 @@ function initAvailableDictionaries(data) {
   });
 }
 
+/**
+ * Method used to fill specified selector with input data values
+ *
+ * @param {String} type of specificied select element (supported values are: 'game', 'mode', and 'language')
+ * @param {Array} values to be displayed as options is specified select element
+ */
 function fillSelector(type, values) {
   let selector = document.getElementById(`dictionary-selector-${type}`);
   if (selector === null) {
@@ -54,6 +71,9 @@ function fillSelector(type, values) {
   selector.innerHTML = optionsHtml;
 }
 
+/**
+ * Method triggered when user changes the value of game select element
+ */
 function gameChanged() {
   let gameSelector = document.getElementById(`dictionary-selector-game`);
   let modeSelector = document.getElementById(`dictionary-selector-mode`);
@@ -65,6 +85,9 @@ function gameChanged() {
   modeSelector.disabled = selectedGame === "";
 }
 
+/**
+ * Method triggered when user changes the value of mode select element
+ */
 function modeChanged() {
   let modeSelector = document.getElementById(`dictionary-selector-mode`);
   let langSelector = document.getElementById(`dictionary-selector-language`);
@@ -76,6 +99,9 @@ function modeChanged() {
   langSelector.disabled = selectedMode === "";
 }
 
+/**
+ * Method triggered when user changes the value of language select element
+ */
 function languageChanged() {
   let langSelector = document.getElementById(`dictionary-selector-language`);
   if (langSelector === null) {

--- a/frontend/js/words-dictionary.js
+++ b/frontend/js/words-dictionary.js
@@ -41,22 +41,31 @@ function fillSelector(type, values) {
 
 function gameChanged() {
   let gameSelector = document.getElementById(`dictionary-selector-game`);
+  let modeSelector = document.getElementById(`dictionary-selector-mode`);
+  if (gameSelector === null || modeSelector === null) {
+    return;
+  }
   selectedGame = gameSelector.value;
   fillSelector("mode", Object.keys(availableDictionaries[selectedGame]));
-  let modeSelector = document.getElementById(`dictionary-selector-mode`);
   modeSelector.disabled = selectedGame === "";
 }
 
 function modeChanged() {
   let modeSelector = document.getElementById(`dictionary-selector-mode`);
+  let langSelector = document.getElementById(`dictionary-selector-language`);
+  if (modeSelector === null || langSelector === null) {
+    return;
+  }
   selectedMode = modeSelector.value;
   fillSelector("language", availableDictionaries[selectedGame][selectedMode]);
-  let langSelector = document.getElementById(`dictionary-selector-language`);
   langSelector.disabled = selectedMode === "";
 }
 
 function languageChanged() {
   let langSelector = document.getElementById(`dictionary-selector-language`);
+  if (langSelector === null) {
+    return;
+  }
   selectedLanguage = langSelector.value;
   loadWords();
 }

--- a/frontend/js/words-dictionary.js
+++ b/frontend/js/words-dictionary.js
@@ -13,6 +13,7 @@ function fillDictionarySelectors() {
     } else {
       initAvailableDictionaries(Object.values(data));
       fillSelector("game", Object.keys(availableDictionaries));
+      initSelectorsValues();
     }
   });
 }

--- a/frontend/js/words-dictionary.js
+++ b/frontend/js/words-dictionary.js
@@ -12,13 +12,13 @@ function fillDictionarySelectors() {
 }
 
 function gameChanged() {
-    console.log("Game changed");
+  console.log("Game changed");
 }
 
 function modeChanged() {
-    console.log("Mode changed");
+  console.log("Mode changed");
 }
 
 function languageChanged() {
-    console.log("Language changed");
+  console.log("Language changed");
 }

--- a/frontend/js/words-dictionary.js
+++ b/frontend/js/words-dictionary.js
@@ -10,10 +10,13 @@ var selectedLanguage = "pl";
  * Method used to fill dictionary selectors (especially the starting one: game selector)
  */
 function fillDictionarySelectors() {
+  loadDictionariesUpdateUI(STATE_WORDS_LOAD);
   getDictionaries((err, data) => {
     if (err) {
+      loadDictionariesUpdateUI(STATE_WORDS_ERROR);
       console.log("ERROR " + err.status + ": " + err.message);
     } else {
+      loadDictionariesUpdateUI(STATE_WORDS_OK);
       initAvailableDictionaries(Object.values(data));
       fillSelector("game", Object.keys(availableDictionaries));
       initSelectorsValues();

--- a/frontend/js/words-dictionary.js
+++ b/frontend/js/words-dictionary.js
@@ -1,7 +1,10 @@
+var availableDictionaries = {};
+
+// variables holding the currently selected dictionary game, mode, and language
+// also they serve a purpose to initialize selector values with starting values
 var selectedGame = "quiz";
 var selectedMode = "0";
 var selectedLanguage = "pl";
-var availableDictionaries = {};
 
 function fillDictionarySelectors() {
   getDictionaries((err, data) => {

--- a/frontend/js/words-dictionary.js
+++ b/frontend/js/words-dictionary.js
@@ -29,10 +29,13 @@ function initAvailableDictionaries(data) {
 
 function fillSelector(type, values) {
   let selector = document.getElementById(`dictionary-selector-${type}`);
-  let optionsHtml = `<option value="" default selected hidden>select ${type}</option>`;
-  values.forEach((value) => {
-    optionsHtml += `<option value="${value}">${value}</option>`;
-  });
+  if (selector === null) {
+    console.log(`Cannot find a dictionary selector element for ${type}...`);
+    return;
+  }
+  const defaultSelectorOption = `<option value="" default selected hidden>select ${type}</option>`;
+  let optionsHtml = defaultSelectorOption
+  values.forEach((value) => optionsHtml += `<option value="${value}">${value}</option>`);
   selector.innerHTML = optionsHtml;
 }
 

--- a/frontend/js/words-dictionary.js
+++ b/frontend/js/words-dictionary.js
@@ -9,17 +9,21 @@ function fillDictionarySelectors() {
     if (err) {
       console.log("ERROR " + err.status + ": " + err.message);
     } else {
-      Object.values(data).forEach((dictionary) => {
-        if (!availableDictionaries[dictionary.game]) {
-          availableDictionaries[dictionary.game] = {};
-        }
-        if (!availableDictionaries[dictionary.game][dictionary.mode]) {
-          availableDictionaries[dictionary.game][dictionary.mode] = [];
-        }
-        availableDictionaries[dictionary.game][dictionary.mode].push(dictionary.language);
-      });
+      initAvailableDictionaries(Object.values(data));
       fillSelector("game", Object.keys(availableDictionaries));
     }
+  });
+}
+
+function initAvailableDictionaries(data) {
+  data.forEach((dict) => {
+    if (!availableDictionaries[dict.game]) {
+      availableDictionaries[dict.game] = {};
+    }
+    if (!availableDictionaries[dict.game][dict.mode]) {
+      availableDictionaries[dict.game][dict.mode] = [];
+    }
+    availableDictionaries[dict.game][dict.mode].push(dict.language);
   });
 }
 

--- a/frontend/js/words-dictionary.js
+++ b/frontend/js/words-dictionary.js
@@ -39,7 +39,9 @@ function gameChanged() {
 }
 
 function modeChanged() {
+  let gameSelector = document.getElementById(`dictionary-selector-game`);
   let modeSelector = document.getElementById(`dictionary-selector-mode`);
+  fillSelector("language", availableDictionaries[gameSelector.value][modeSelector.value]);
   let langSelector = document.getElementById(`dictionary-selector-language`);
   langSelector.disabled = modeSelector.value === "";
 }

--- a/frontend/js/words-dictionary.js
+++ b/frontend/js/words-dictionary.js
@@ -41,11 +41,11 @@ function gameChanged() {
 }
 
 function modeChanged() {
-  let gameSelector = document.getElementById(`dictionary-selector-game`);
   let modeSelector = document.getElementById(`dictionary-selector-mode`);
-  fillSelector("language", availableDictionaries[gameSelector.value][modeSelector.value]);
+  selectedMode = modeSelector.value;
+  fillSelector("language", availableDictionaries[selectedGame][selectedMode]);
   let langSelector = document.getElementById(`dictionary-selector-language`);
-  langSelector.disabled = modeSelector.value === "";
+  langSelector.disabled = selectedMode === "";
 }
 
 function languageChanged() {

--- a/frontend/js/words-dictionary.js
+++ b/frontend/js/words-dictionary.js
@@ -85,4 +85,5 @@ function languageChanged() {
   loadWords();
 }
 
+// called on words.html site load
 fillDictionarySelectors();

--- a/frontend/js/words-dictionary.js
+++ b/frontend/js/words-dictionary.js
@@ -22,3 +22,5 @@ function modeChanged() {
 function languageChanged() {
   console.log("Language changed");
 }
+
+fillDictionarySelectors();

--- a/frontend/js/words-dictionary.js
+++ b/frontend/js/words-dictionary.js
@@ -17,9 +17,7 @@ function fillDictionarySelectors() {
         }
         availableDictionaries[dictionary.game][dictionary.mode].push(dictionary.language);
       });
-      fillSelector("game", Array.from(availableGames.values()));
-      fillSelector("mode", Array.from(availableModes.values()));
-      fillSelector("language", Array.from(availableLangs.values()));
+      fillSelector("game", Object.keys(availableDictionaries));
     }
   });
 }

--- a/frontend/js/words-dictionary.js
+++ b/frontend/js/words-dictionary.js
@@ -108,7 +108,7 @@ function languageChanged() {
     return;
   }
   selectedLanguage = langSelector.value;
-  loadWords();
+  loadWords(selectedGame, selectedMode, selectedLanguage);
 }
 
 // called on words.html site load

--- a/frontend/js/words-dictionary.js
+++ b/frontend/js/words-dictionary.js
@@ -1,14 +1,33 @@
 var selectedMode = "0";
 var selectedLanguage = "pl";
+var availableGames = new Set();
+var availableModes = new Set();
+var availableLangs = new Set();
 
 function fillDictionarySelectors() {
   getDictionaries((err, data) => {
     if (err) {
       console.log("ERROR " + err.status + ": " + err.message);
     } else {
-      console.log(data);
+      Object.values(data).forEach(dictionary => {
+        availableGames.add(dictionary.game);
+        availableModes.add(dictionary.mode);
+        availableLangs.add(dictionary.language);
+      });
+      fillSelector("game", Array.from(availableGames.values()));
+      fillSelector("mode", Array.from(availableModes.values()));
+      fillSelector("language", Array.from(availableLangs.values()));
     }
   });
+}
+
+function fillSelector(type, values) {
+    let selector = document.getElementById(`dictionary-selector-${type}`);
+    let optionsHtml = `<option value="" default selected hidden>select ${type}</option>`;
+    values.forEach(value => {
+        optionsHtml += `<option value="${value}">${value}</option>`;
+    })
+    selector.innerHTML = optionsHtml;
 }
 
 function gameChanged() {

--- a/frontend/js/words-dictionary.js
+++ b/frontend/js/words-dictionary.js
@@ -9,7 +9,7 @@ function fillDictionarySelectors() {
     if (err) {
       console.log("ERROR " + err.status + ": " + err.message);
     } else {
-      Object.values(data).forEach(dictionary => {
+      Object.values(data).forEach((dictionary) => {
         availableGames.add(dictionary.game);
         availableModes.add(dictionary.mode);
         availableLangs.add(dictionary.language);

--- a/frontend/js/words-dictionary.js
+++ b/frontend/js/words-dictionary.js
@@ -43,7 +43,7 @@ function modeChanged() {
 }
 
 function languageChanged() {
-  console.log("Language changed");
+  loadWords();
 }
 
 fillDictionarySelectors();

--- a/frontend/js/words-state.js
+++ b/frontend/js/words-state.js
@@ -2,6 +2,11 @@ const STATE_WORDS_OK = 0;
 const STATE_WORDS_LOAD = 1;
 const STATE_WORDS_ERROR = 2;
 
+/**
+ * Method used to update GUI state while loading words dictionary from service
+ *
+ * @param {Integer} state current loading state (from: STATE_WORDS_OK, STATE_WORDS_LOAD, STATE_WORDS_ERROR)
+ */
 function loadDictionariesUpdateUI(state) {
   let rowElement = document.getElementById("no-words-row");
   let textElement = document.getElementById("no-words-text");

--- a/frontend/js/words-state.js
+++ b/frontend/js/words-state.js
@@ -2,6 +2,28 @@ const STATE_WORDS_OK = 0;
 const STATE_WORDS_LOAD = 1;
 const STATE_WORDS_ERROR = 2;
 
+function loadDictionariesUpdateUI(state) {
+  let rowElement = document.getElementById("no-words-row");
+  let textElement = document.getElementById("no-words-text");
+  if (rowElement === null || textElement === null) return;
+  addWordUpdateUI(state);
+  if (STATE_WORDS_OK === state) {
+    rowElement.className = "row-hidden no-select";
+    textElement.innerHTML = "";
+    return;
+  }
+  if (STATE_WORDS_LOAD === state) {
+    rowElement.className = "row-loading no-select";
+    textElement.innerHTML = addLoadingWidget() + "<br>loading dictionaries...";
+    return;
+  }
+  if (STATE_WORDS_ERROR === state) {
+    rowElement.className = "row-visible no-select";
+    textElement.innerHTML = addErrorWidget() + "<br>cannot receive dictionaries...";
+    return;
+  }
+}
+
 /**
  * Method used to update GUI state while loading words from service
  *

--- a/frontend/js/words-state.js
+++ b/frontend/js/words-state.js
@@ -9,22 +9,22 @@ const STATE_WORDS_ERROR = 2;
  */
 function loadDictionariesUpdateUI(state) {
   let rowElement = document.getElementById("no-words-row");
-  let textElement = document.getElementById("no-words-text");
-  if (rowElement === null || textElement === null) return;
+  let contentElement = document.getElementById("no-words-content");
+  if (rowElement === null || contentElement === null) return;
   addWordUpdateUI(state);
   if (STATE_WORDS_OK === state) {
     rowElement.className = "row-hidden no-select";
-    textElement.innerHTML = "";
+    contentElement.innerHTML = "";
     return;
   }
   if (STATE_WORDS_LOAD === state) {
     rowElement.className = "row-loading no-select";
-    textElement.innerHTML = addLoadingWidget() + "<br>loading dictionaries...";
+    contentElement.innerHTML = addLoadingWidget() + "<p>loading dictionaries...</p>";
     return;
   }
   if (STATE_WORDS_ERROR === state) {
     rowElement.className = "row-visible no-select";
-    textElement.innerHTML = addErrorWidget() + "<br>cannot receive dictionaries...";
+    contentElement.innerHTML = addErrorWidget() + "<p>cannot receive dictionaries...";
     return;
   }
 }
@@ -36,22 +36,22 @@ function loadDictionariesUpdateUI(state) {
  */
 function loadWordsUpdateUI(state) {
   let rowElement = document.getElementById("no-words-row");
-  let textElement = document.getElementById("no-words-text");
-  if (rowElement === null || textElement === null) return;
+  let contentElement = document.getElementById("no-words-content");
+  if (rowElement === null || contentElement === null) return;
   addWordUpdateUI(state);
   if (STATE_WORDS_OK === state) {
     rowElement.className = "row-hidden no-select";
-    textElement.innerHTML = "";
+    contentElement.innerHTML = "";
     return;
   }
   if (STATE_WORDS_LOAD === state) {
     rowElement.className = "row-loading no-select";
-    textElement.innerHTML = addLoadingWidget() + "<br>loading words...";
+    contentElement.innerHTML = addLoadingWidget() + "<p>loading words...</p>";
     return;
   }
   if (STATE_WORDS_ERROR === state) {
     rowElement.className = "row-visible no-select";
-    textElement.innerHTML = addErrorWidget() + "<br>cannot receive words...";
+    contentElement.innerHTML = addErrorWidget() + "<p>cannot receive words...</p>";
     return;
   }
 }

--- a/frontend/js/words.js
+++ b/frontend/js/words.js
@@ -132,10 +132,14 @@ function getWordTableRow(item) {
 
 /**
  * Method used to load all words and add them to HTML table DOM
+ *
+ * @param {String} game type of the game for which we want to (re)load words view
+ * @param {String} mode specific game mode for which we want to (re)load words view
+ * @param {String} language type of language for which we want to (re)load words view
  */
-function loadWords() {
+function loadWords(game, mode, language) {
   loadWordsUpdateUI(STATE_WORDS_LOAD);
-  getWords(selectedMode, selectedLanguage, (err, data) => {
+  getWords(game, mode, language, (err, data) => {
     if (err) {
       loadWordsUpdateUI(STATE_WORDS_ERROR);
     } else {

--- a/frontend/js/words.js
+++ b/frontend/js/words.js
@@ -191,6 +191,3 @@ function validateWord(word) {
   }
   return true;
 }
-
-// called on words.html site load
-loadWords();

--- a/frontend/js/words.js
+++ b/frontend/js/words.js
@@ -138,13 +138,17 @@ function getWordTableRow(item) {
  * @param {String} language type of language for which we want to (re)load words view
  */
 function loadWords(game, mode, language) {
+  var wordsTableBody = document.querySelector("table#table-words tbody");
+  wordsTableBody.innerHTML = `<tr id="no-words-row">
+                                <td id="no-words-content" rowspan="4"></td>
+                              </tr>`;
   loadWordsUpdateUI(STATE_WORDS_LOAD);
   getWords(game, mode, language, (err, data) => {
     if (err) {
       loadWordsUpdateUI(STATE_WORDS_ERROR);
     } else {
       loadWordsUpdateUI(STATE_WORDS_OK);
-      document.querySelector("tbody").innerHTML = Object.values(data)
+      wordsTableBody.innerHTML += Object.values(data)
         .map((item) => getWordTableRow(item))
         .join("");
     }

--- a/frontend/js/words.js
+++ b/frontend/js/words.js
@@ -104,7 +104,7 @@ function refreshWordsCallback(err, data) {
     changeWordUpdateUI(0 === err.status ? STATE_WORDS_ERROR : STATE_WORDS_OK);
   } else {
     wordChangeShowToast(WORD_TOAST_INFO, data);
-    loadWords();
+    loadWords(selectedGame, selectedMode, selectedLanguage);
     changeWordUpdateUI(STATE_WORDS_OK);
   }
 }

--- a/frontend/js/words.js
+++ b/frontend/js/words.js
@@ -49,7 +49,7 @@ function acceptWord() {
       return;
     }
     changeWordUpdateUI(STATE_WORDS_LOAD);
-    postWord(acceptedWord, refreshWordsCallback);
+    postWord(acceptedWord, selectedMode, selectedLanguage, refreshWordsCallback);
   } else if (FORM_MODE_EDIT === wordFormMode) {
     if (undefined === wordUnderEdition) {
       wordChangeShowToast(WORD_TOAST_ERROR, "ERROR: word under edition cannot be undefined");
@@ -63,7 +63,7 @@ function acceptWord() {
       return;
     }
     changeWordUpdateUI(STATE_WORDS_LOAD);
-    putWord(wordUnderEdition.name, acceptedWord, refreshWordsCallback);
+    putWord(wordUnderEdition.name, acceptedWord, selectedMode, selectedLanguage, refreshWordsCallback);
   } else {
     wordChangeShowToast(WORD_TOAST_ERROR, "ERROR: Unknown form mode: " + wordFormMode);
   }
@@ -89,7 +89,7 @@ function getWordFromUi() {
  */
 function removeWord(name) {
   changeWordUpdateUI(STATE_WORDS_LOAD);
-  deleteWord(name, refreshWordsCallback);
+  deleteWord(name, selectedMode, selectedLanguage, refreshWordsCallback);
 }
 
 /**
@@ -135,7 +135,7 @@ function getWordTableRow(item) {
  */
 function loadWords() {
   loadWordsUpdateUI(STATE_WORDS_LOAD);
-  getWords((err, data) => {
+  getWords(selectedMode, selectedLanguage, (err, data) => {
     if (err) {
       loadWordsUpdateUI(STATE_WORDS_ERROR);
     } else {

--- a/frontend/words.html
+++ b/frontend/words.html
@@ -94,7 +94,9 @@
           </thead>
           <tbody>
             <tr id="no-words-row" class="row-loading">
-              <td id="no-words-content" rowspan="4">loading...</td>
+              <td id="no-words-content" rowspan="4">
+                <p>loading...</p>
+              </td>
             </tr>
           </tbody>
         </table>

--- a/frontend/words.html
+++ b/frontend/words.html
@@ -60,19 +60,19 @@
         <span class="dictionary-selector-header">dictionary selector</span>
         <div>
           <label for="dictionary-selector-game" class="dictionary-selector-label">game:</label>
-          <select name="games" id="dictionary-selector-game" onchange="gameChanged()" required>
+          <select name="games" id="dictionary-selector-game" onchange="gameChanged()">
             <option value="" default selected hidden>select game</option>
           </select>
         </div>
         <div>
           <label for="dictionary-selector-mode" class="dictionary-selector-label">mode:</label>
-          <select name="modes" id="dictionary-selector-mode" onchange="modeChanged()" required disabled>
+          <select name="modes" id="dictionary-selector-mode" onchange="modeChanged()" disabled>
             <option value="" default selected hidden>select mode</option>
           </select>
         </div>
         <div>
           <label for="dictionary-selector-language" class="dictionary-selector-label">language:</label>
-          <select name="languages" id="dictionary-selector-language" onchange="languageChanged()" required disabled>
+          <select name="languages" id="dictionary-selector-language" onchange="languageChanged()" disabled>
             <option value="" default selected hidden>select language</option>
           </select>
         </div>

--- a/frontend/words.html
+++ b/frontend/words.html
@@ -10,8 +10,8 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Pacifico&display=swap" rel="stylesheet" />
     <script src="./js/words-api.js" defer></script>
-    <script src="./js/words-dictionary.js" defer></script>
     <script src="./js/words-state.js" defer></script>
+    <script src="./js/words-dictionary.js" defer></script>
     <script src="./js/words.js" defer></script>
   </head>
   <body>

--- a/frontend/words.html
+++ b/frontend/words.html
@@ -94,7 +94,7 @@
           </thead>
           <tbody>
             <tr id="no-words-row" class="row-loading">
-              <td id="no-words-text" rowspan="4">loading...</td>
+              <td id="no-words-content" rowspan="4">loading...</td>
             </tr>
           </tbody>
         </table>

--- a/frontend/words.html
+++ b/frontend/words.html
@@ -59,6 +59,12 @@
       <div id="dictionary-selector">
         <span class="dictionary-selector-header">dictionary selector</span>
         <div>
+          <label for="dictionary-selector-game" class="dictionary-selector-label">game:</label>
+          <select name="games" id="dictionary-selector-game" required>
+            <option value="" default selected hidden>select game</option>
+          </select>
+        </div>
+        <div>
           <label for="dictionary-selector-mode" class="dictionary-selector-label">mode:</label>
           <select name="modes" id="dictionary-selector-mode" required>
             <option value="" default selected hidden>select mode</option>

--- a/frontend/words.html
+++ b/frontend/words.html
@@ -60,19 +60,19 @@
         <span class="dictionary-selector-header">dictionary selector</span>
         <div>
           <label for="dictionary-selector-game" class="dictionary-selector-label">game:</label>
-          <select name="games" id="dictionary-selector-game" required>
+          <select name="games" id="dictionary-selector-game" onchange="gameChanged()" required>
             <option value="" default selected hidden>select game</option>
           </select>
         </div>
         <div>
           <label for="dictionary-selector-mode" class="dictionary-selector-label">mode:</label>
-          <select name="modes" id="dictionary-selector-mode" required>
+          <select name="modes" id="dictionary-selector-mode" onchange="modeChanged()" required disabled>
             <option value="" default selected hidden>select mode</option>
           </select>
         </div>
         <div>
           <label for="dictionary-selector-language" class="dictionary-selector-label">language:</label>
-          <select name="languages" id="dictionary-selector-language" required>
+          <select name="languages" id="dictionary-selector-language" onchange="languageChanged()" required disabled>
             <option value="" default selected hidden>select language</option>
           </select>
         </div>

--- a/frontend/words.html
+++ b/frontend/words.html
@@ -10,6 +10,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Pacifico&display=swap" rel="stylesheet" />
     <script src="./js/words-api.js" defer></script>
+    <script src="./js/words-dictionary.js" defer></script>
     <script src="./js/words-state.js" defer></script>
     <script src="./js/words.js" defer></script>
   </head>

--- a/frontend/words.html
+++ b/frontend/words.html
@@ -60,7 +60,7 @@
         <span class="dictionary-selector-header">dictionary selector</span>
         <div>
           <label for="dictionary-selector-game" class="dictionary-selector-label">game:</label>
-          <select name="games" id="dictionary-selector-game" onchange="gameChanged()">
+          <select name="games" id="dictionary-selector-game" onchange="gameChanged()" disabled>
             <option value="" default selected hidden>select game</option>
           </select>
         </div>


### PR DESCRIPTION
Added game, mode and language select elements to handle multiple words dictionaries + updated UI state handling.
By default all selectors are disabled and frontend is trying to connect to Word Service and receive dictionaries information
![image](https://user-images.githubusercontent.com/22420752/213830138-251267ac-7cee-4c72-a2b1-f494493944cc.png)
When this succeeds the default initial dictionary is selected and ony then the words are received for this specified dictionary (this is done when user changes the language:
![image](https://user-images.githubusercontent.com/22420752/213830262-7e62d81d-1573-44ed-9929-bd212974d0c1.png)
This patch fixes #39 