### PR TITLE
Added save quiz modes logic after add, remove and update operation

### DIFF
--- a/backend/service-quiz/src/main/scala/pl/smtc/smartwords/database/ModeDatabase.scala
+++ b/backend/service-quiz/src/main/scala/pl/smtc/smartwords/database/ModeDatabase.scala
@@ -5,8 +5,9 @@ import io.circe.parser._
 import pl.smtc.smartwords.dao._
 import pl.smtc.smartwords.model._
 
-import java.io.{BufferedInputStream, File, FileInputStream}
-import java.nio.file.{Path, Paths}
+import java.io._
+import java.nio.charset.StandardCharsets
+import java.nio.file._
 import scala.collection.mutable.ListBuffer
 import scala.io.Source
 import scala.util.Using
@@ -38,6 +39,14 @@ class ModeDatabase {
       }
     }
     result
+  }
+
+  /**
+   * Method used to save current quiz mode database into JSON file
+   */
+  def saveDatabase(): Unit = {
+    val content: String = quizModes.asJson.toString()
+    Files.write(resourceDir.resolve(quizModesFile), content.getBytes(StandardCharsets.UTF_8))
   }
 
   /**

--- a/backend/service-quiz/src/main/scala/pl/smtc/smartwords/database/ModeDatabase.scala
+++ b/backend/service-quiz/src/main/scala/pl/smtc/smartwords/database/ModeDatabase.scala
@@ -65,6 +65,7 @@ class ModeDatabase {
     val freeId: Int = quizModes.map(mode => mode.id).max + 1
     val newMode: Mode = Mode(freeId, "", "", List(), deletable = true)
     quizModes += newMode
+    saveDatabase()
     newMode
   }
 
@@ -85,6 +86,7 @@ class ModeDatabase {
     }
     newMode.id = id
     quizModes.update(idIndex, newMode)
+    saveDatabase()
     true
   }
 
@@ -102,6 +104,7 @@ class ModeDatabase {
       return false
     }
     quizModes.remove(idIndex)
+    saveDatabase()
     true
   }
 

--- a/backend/service-quiz/src/main/scala/pl/smtc/smartwords/database/ModeDatabase.scala
+++ b/backend/service-quiz/src/main/scala/pl/smtc/smartwords/database/ModeDatabase.scala
@@ -2,6 +2,7 @@ package pl.smtc.smartwords.database
 
 import io.circe._
 import io.circe.parser._
+import io.circe.syntax._
 import pl.smtc.smartwords.dao._
 import pl.smtc.smartwords.model._
 
@@ -15,6 +16,7 @@ import scala.util.Using
 class ModeDatabase {
 
   implicit val ModeDecoder: Decoder[Mode] = ModeDao.getModeDecoder
+  implicit val ModeEncoder: Encoder[Mode] = ModeDao.getModeEncoder
 
   private val quizModes: ListBuffer[Mode] = ListBuffer()
   private val quizModesFile: String = "modes.json"


### PR DESCRIPTION
Updated quiz modes logic to save modes database changes into an internal JSON file.
This operation is done after adding new mode, updating or removing exisitng one.

This pull request fixes #50 