### PR TITLE
Added dirty marker to quiz modes settings table

### DIFF
--- a/frontend/css/settings.css
+++ b/frontend/css/settings.css
@@ -523,6 +523,12 @@ button#quiz-modes-save {
   font-family: var(--styled-font), cursive;
 }
 
+button#quiz-modes-save:disabled {
+  background-color: gainsboro;
+  border-color: lightgray;
+  color: gray;
+}
+
 /************************************/
 /* quiz modes tab - settings        */
 /************************************/

--- a/frontend/css/settings.css
+++ b/frontend/css/settings.css
@@ -457,7 +457,7 @@ table#quiz-modes-available td:first-child {
 }
 
 table#quiz-modes-available td:last-child {
-  padding-left: 15px;
+  padding-left: 30px;
 }
 
 button#quiz-modes-add {

--- a/frontend/css/settings.css
+++ b/frontend/css/settings.css
@@ -452,6 +452,13 @@ table#quiz-modes-available td button.delete-mode:hover {
   box-shadow: inset 0 0 2px black;
 }
 
+table#quiz-modes-available td div.dirty-mode-marker {
+  position: absolute;
+  top: 6px;
+  left: -10px;
+  width: 60px;
+}
+
 table#quiz-modes-available td:first-child {
   text-align: center;
 }

--- a/frontend/js/settings-tab-quiz.js
+++ b/frontend/js/settings-tab-quiz.js
@@ -77,6 +77,7 @@ function updateQuizMode() {
       // disable save button so the user cannot save changes
       updateSaveModeButtonEnableState(false);
       updateQuizModesTable();
+      updateQuizModesTableSelection(currentlyEditedMode.id);
     }
   });
 }
@@ -217,6 +218,7 @@ function storeCurrentValuesInQuizMode(mode) {
     mode.name = newModeName;
     if (updateTable) {
       updateQuizModesTable();
+      updateQuizModesTableSelection(mode.id);
     }
     mode.description = getEditedModeInputValue("general-desc");
     mode.settings.forEach(setting => {
@@ -253,6 +255,7 @@ function markCurrentlyEditedModeAsDirty() {
     updateQuizModesTable();
     // enable save button so the user can save changes
     updateSaveModeButtonEnableState(true);
+    updateQuizModesTableSelection(currentlyEditedMode.id);
   }
 }
 

--- a/frontend/js/settings-tab-quiz.js
+++ b/frontend/js/settings-tab-quiz.js
@@ -57,6 +57,7 @@ function createQuizMode() {
     } else {
       availableQuizModes.push(data);
       updateQuizModesTable();
+      selectMode(data.id);
     }
   });
 }

--- a/frontend/js/settings-tab-quiz.js
+++ b/frontend/js/settings-tab-quiz.js
@@ -255,7 +255,7 @@ function createModesTableContent(modes) {
                 <td>${mode.id}</td>
                 <td>
                   ${mode.name}
-                  ${dirtyQuizModes.has(mode.id) ? "*" : ""}
+                  ${dirtyQuizModes.has(mode.id) ? createDirtyModeMarker() : ""}
                   ${mode.deletable ? createDeleteModeButton(mode.id) : ""}
                 </td>
               </tr>`;

--- a/frontend/js/settings-tab-quiz.js
+++ b/frontend/js/settings-tab-quiz.js
@@ -749,7 +749,7 @@ function handleBoxDrop(e) {
       let newSetting = availableModeSettings.find(
         (setting) => setting.type === getSettingBoxName(currentlyDraggedElement)
       );
-      currentlyEditedMode.settings.splice(dropPosition, 0, newSetting);
+      currentlyEditedMode.settings.splice(dropPosition, 0, structuredClone(newSetting));
     }
   } else {
     // we are dropping setting box to delete drop target

--- a/frontend/js/settings-tab-quiz.js
+++ b/frontend/js/settings-tab-quiz.js
@@ -376,6 +376,10 @@ function createDeleteModeButton(id) {
           </button>`;
 }
 
+function createDirtyModeMarker() {
+  return `<div class="dirty-mode-marker">💾❗</div>`;
+}
+
 /**
  * Method used to create HTML code for collapsible content of specified type
  *

--- a/frontend/js/settings-tab-quiz.js
+++ b/frontend/js/settings-tab-quiz.js
@@ -74,6 +74,8 @@ function updateQuizMode() {
     } else {
       console.log(data);
       dirtyQuizModes.delete(currentlyEditedMode.id);
+      // disable save button so the user cannot save changes
+      document.getElementById("quiz-modes-save").disabled = true;
       updateQuizModesTable();
     }
   });
@@ -239,6 +241,8 @@ function markCurrentlyEditedModeAsDirty() {
   if (!dirtyQuizModes.has(currentlyEditedMode.id)) {
     dirtyQuizModes.add(currentlyEditedMode.id);
     updateQuizModesTable();
+    // enable save button so the user can save changes
+    document.getElementById("quiz-modes-save").disabled = false;
   }
 }
 

--- a/frontend/js/settings-tab-quiz.js
+++ b/frontend/js/settings-tab-quiz.js
@@ -195,6 +195,11 @@ function updateCurrentlyEditedMode() {
   return false;
 }
 
+/**
+ * Method used to update the enabled state of save quiz mode button
+ *
+ * @param {Boolean} enabled flag indicating if button should be enabled (true), or disabled (false)
+ */
 function updateSaveModeButtonEnableState(enabled) {
   document.getElementById("quiz-modes-save").disabled = !enabled;
 }
@@ -385,6 +390,11 @@ function createDeleteModeButton(id) {
           </button>`;
 }
 
+/**
+ * Method used to create a divider element with dirty/changed/to save marker
+ *
+ * @returns HTML code with divider containig dirty marker icon
+ */
 function createDirtyModeMarker() {
   return `<div class="dirty-mode-marker">💾❗</div>`;
 }

--- a/frontend/js/settings-tab-quiz.js
+++ b/frontend/js/settings-tab-quiz.js
@@ -75,7 +75,7 @@ function updateQuizMode() {
       console.log(data);
       dirtyQuizModes.delete(currentlyEditedMode.id);
       // disable save button so the user cannot save changes
-      document.getElementById("quiz-modes-save").disabled = true;
+      updateSaveModeButtonEnableState(false);
       updateQuizModesTable();
     }
   });
@@ -118,7 +118,7 @@ function selectMode(modeId) {
   updateQuizModesTableSelection(modeId);
   updateQuizModesPlaceholder(currentlyEditedMode);
   updateSupportedSettingsBoxes();
-  document.getElementById("quiz-modes-save").disabled = !dirtyQuizModes.has(modeId);
+  updateSaveModeButtonEnableState(dirtyQuizModes.has(modeId));
 }
 
 /**
@@ -247,7 +247,7 @@ function markCurrentlyEditedModeAsDirty() {
     dirtyQuizModes.add(currentlyEditedMode.id);
     updateQuizModesTable();
     // enable save button so the user can save changes
-    document.getElementById("quiz-modes-save").disabled = false;
+    updateSaveModeButtonEnableState(true);
   }
 }
 

--- a/frontend/js/settings-tab-quiz.js
+++ b/frontend/js/settings-tab-quiz.js
@@ -65,6 +65,9 @@ function createQuizMode() {
  * Method used to save quiz mode changes and handle UI update
  */
 function updateQuizMode() {
+  if (currentlyEditedMode === undefined) {
+    return;
+  }
   if (!updateCurrentlyEditedMode()) {
     return;
   }

--- a/frontend/js/settings-tab-quiz.js
+++ b/frontend/js/settings-tab-quiz.js
@@ -118,6 +118,7 @@ function selectMode(modeId) {
   updateQuizModesTableSelection(modeId);
   updateQuizModesPlaceholder(currentlyEditedMode);
   updateSupportedSettingsBoxes();
+  document.getElementById("quiz-modes-save").disabled = !dirtyQuizModes.has(modeId);
 }
 
 /**

--- a/frontend/js/settings-tab-quiz.js
+++ b/frontend/js/settings-tab-quiz.js
@@ -195,6 +195,10 @@ function updateCurrentlyEditedMode() {
   return false;
 }
 
+function updateSaveModeButtonEnableState(enabled) {
+  document.getElementById("quiz-modes-save").disabled = !enabled;
+}
+
 /**
  * Method used to store current UI values in the specified quiz modeo object
  *

--- a/frontend/settings.html
+++ b/frontend/settings.html
@@ -51,7 +51,7 @@
           <div id="selected-mode-edit" class="quiz-modes-section">
             <p class="section-title">current mode settings</p>
             <div id="mode-placeholder" class="mode-deselected">select mode from available quiz modes table</div>
-            <button id="quiz-modes-save" class="dynamic-border" onclick="updateQuizMode()">
+            <button id="quiz-modes-save" class="dynamic-border" onclick="updateQuizMode()" disabled>
               save changes
             </button>
           </div>


### PR DESCRIPTION
In this patch I've added a dirty marker which is displayed in quiz modes table when user changes ANYTHING in currently selected mode. Additionally I've updated the quiz mode save button logic and change it's enabled state when mode is changed (dirty) or not. Finally I've fixed a major bug with supported settings reference and changing multiple settings in one go.
This pull request fixes #49 