### PR TITLE
Fixed quiz modes table refresh after removing not selected mode

### DIFF
--- a/frontend/js/settings-tab-quiz.js
+++ b/frontend/js/settings-tab-quiz.js
@@ -100,9 +100,9 @@ function removeQuizMode(modeId) {
       availableQuizModes = availableQuizModes.filter(mode => mode.id !== modeId);
       if (currentlyEditedMode.id === modeId) {
         currentlyEditedMode = undefined;
-        updateQuizModesTable();
-      } else {
-        updateQuizModesTable();
+      }
+      updateQuizModesTable();
+      if (currentlyEditedMode !== undefined) {
         updateQuizModesTableSelection(currentlyEditedMode.id);
       }
       updateQuizModesPlaceholder(currentlyEditedMode);

--- a/frontend/js/settings-tab-quiz.js
+++ b/frontend/js/settings-tab-quiz.js
@@ -98,7 +98,9 @@ function removeQuizMode(modeId) {
     } else {
       console.log(data);
       availableQuizModes = availableQuizModes.filter(mode => mode.id !== modeId);
-      currentlyEditedMode = undefined;
+      if (currentlyEditedMode.id === modeId) {
+        currentlyEditedMode = undefined;
+      }
       updateQuizModesTable();
       updateQuizModesPlaceholder(currentlyEditedMode);
       updateSupportedSettingsBoxes();

--- a/frontend/js/settings-tab-quiz.js
+++ b/frontend/js/settings-tab-quiz.js
@@ -98,10 +98,12 @@ function removeQuizMode(modeId) {
     } else {
       console.log(data);
       availableQuizModes = availableQuizModes.filter(mode => mode.id !== modeId);
+      // clean currently edited mode variable if user removes it
       if (currentlyEditedMode.id === modeId) {
         currentlyEditedMode = undefined;
       }
       updateQuizModesTable();
+      // leave quiz modes table selection if user removed different mode
       if (currentlyEditedMode !== undefined) {
         updateQuizModesTableSelection(currentlyEditedMode.id);
       }

--- a/frontend/js/settings-tab-quiz.js
+++ b/frontend/js/settings-tab-quiz.js
@@ -100,8 +100,11 @@ function removeQuizMode(modeId) {
       availableQuizModes = availableQuizModes.filter(mode => mode.id !== modeId);
       if (currentlyEditedMode.id === modeId) {
         currentlyEditedMode = undefined;
+        updateQuizModesTable();
+      } else {
+        updateQuizModesTable();
+        updateQuizModesTableSelection(currentlyEditedMode.id);
       }
-      updateQuizModesTable();
       updateQuizModesPlaceholder(currentlyEditedMode);
       updateSupportedSettingsBoxes();
     }


### PR DESCRIPTION
Updated logic to NOT refresh quiz modes table after removal.
Table is still updated when removing current mode.
This patch fixes #51 