### PR TITLE
Added default language selection to languages setting in mode options

### DIFF
--- a/backend/service-quiz/src/main/resources/modes.json
+++ b/backend/service-quiz/src/main/resources/modes.json
@@ -8,7 +8,7 @@
       {
         "type": "languages",
         "label": "select language:",
-        "details": "pl en"
+        "details": "en pl!"
       },
       {
         "type": "questions",

--- a/frontend/css/settings.css
+++ b/frontend/css/settings.css
@@ -241,6 +241,7 @@ div.setting-box .collapsible-button:disabled {
 
 div.mode-setting-text-edit,
 div.mode-setting-number-edit,
+div.mode-setting-combo-box,
 div.mode-setting-languages-edit {
   margin: 5px 10px;
 }

--- a/frontend/css/settings.css
+++ b/frontend/css/settings.css
@@ -252,6 +252,12 @@ input.mode-setting-value {
   font-family: var(--clear-font-primary), Verdana, sans-serif;
 }
 
+select.mode-setting-combo {
+  width: 100%;
+  font-size: 15px;
+  font-family: var(--clear-font-primary), Verdana, sans-serif;
+}
+
 label.mode-setting-label {
   display: block;
   width: 100%;

--- a/frontend/js/settings-tab-quiz.js
+++ b/frontend/js/settings-tab-quiz.js
@@ -552,6 +552,16 @@ function createSettingInputCombo(id, watch, labelText, allValues, selectedValue)
           </div>`;
 }
 
+function createSettingComboOptions(allValues, selectedValue) {
+  const emptyOption = `<option value="" disabled selected hidden>select a supported language...</option>`;
+  const options = Object.values(allValues)
+    .map(option => {
+      const selected = option === selectedValue ? "selected" : "";
+      return `<option value="${option}" ${selected}>${option}</option>`;
+    }).join("");
+  return options.length > 0 ? options : emptyOption;
+}
+
 /**
  * Method used to create a single setting input of type language (flag checkboxes) with an appropriate label
  *

--- a/frontend/js/settings-tab-quiz.js
+++ b/frontend/js/settings-tab-quiz.js
@@ -628,19 +628,18 @@ function toggleFlagCheckbox(flagItem, watch) {
 }
 
 function parseLanguageDetails(details) {
-  const languagesArray = details.length > 0 ? details.split(" ") : [];
-  const languageWithMark = languagesArray.find(el => el.indexOf(DEFAULT_LANGUAGE_MARK) > 0);
-  const firstLanguage = languagesArray.length > 0 ? languagesArray[0] : "";
-  const defaultLanguage = languageWithMark !== undefined
-    ? languageWithMark.substring(0, languageWithMark.length - 1)
-    : firstLanguage;
-  const selectedLanguages = languagesArray.map(lang => {
+  const languageArray = details.length > 0 ? details.split(" ") : [];
+  const languageMarked = languageArray.find(el => el.indexOf(DEFAULT_LANGUAGE_MARK) > 0);
+  const languageDefault = languageMarked !== undefined
+    ? languageMarked.substring(0, languageMarked.length - 1)
+    : languageArray.length > 0 ? languageArray[0] : "";
+  const selectedLanguages = languageArray.map(lang => {
     if (lang.indexOf(DEFAULT_LANGUAGE_MARK) > 0) {
       return lang.substring(0, lang.length - 1);
     }
     return lang;
   });
-  return { selected: selectedLanguages, default: defaultLanguage };
+  return { selected: selectedLanguages, default: languageDefault };
 }
 
 /**

--- a/frontend/js/settings-tab-quiz.js
+++ b/frontend/js/settings-tab-quiz.js
@@ -536,6 +536,11 @@ function createSettingInputNumber(id, watch, labelText, initValue, minValue, max
  * @returns HTML code for select element with a label contained in a divider element
  */
 function createSettingInputCombo(id, watch, labelText, allValues, selectedValue) {
+  const options = Object.values(allValues)
+    .map(option => {
+      const selected = option === selectedValue ? "selected" : "";
+      return `<option value="${option}" ${selected}>${option}</option>`;
+    }).join("");
   return `<div class="mode-setting-combo-box">
             <label class="mode-setting-label" for="${id}">${labelText}</label>
             <select id="${id}" class="mode-setting-combo" name="${id}" ${watch ? `onchange="updateCurrentlyEditedMode()"` : ``}>

--- a/frontend/js/settings-tab-quiz.js
+++ b/frontend/js/settings-tab-quiz.js
@@ -524,7 +524,17 @@ function createSettingInputNumber(id, watch, labelText, initValue, minValue, max
           </div>`;
 }
 
-function createSettingInputCombo(id, watch, labelText, allValues, comboValue) {
+/**
+ * Method used to create a single setting combo box of type select with an appropriate label
+ *
+ * @param {Integer} id unique identifier of the created select
+ * @param {Boolean} watch flag used to indetify if we should watch select option change and update mode dirty state
+ * @param {String} labelText the text displayed in a label
+ * @param {Integer} allValues all combo box options to be displayed in select element
+ * @param {Integer} selectedValue initial combo box selected option
+ * @returns HTML code for select element with a label contained in a divider element
+ */
+function createSettingInputCombo(id, watch, labelText, allValues, selectedValue) {
   return `<div class="mode-setting-combo-box">
             <label class="mode-setting-label" for="${id}">${labelText}</label>
             <select id="${id}" class="mode-setting-combo" name="${id}" ${watch ? `onchange="updateCurrentlyEditedMode()"` : ``}>
@@ -633,6 +643,12 @@ function getEditedModeInputValue(inputId) {
   return inputElement.value;
 }
 
+/**
+ * Method used to receive edited mode selected value from an combo box determined by ID
+ *
+ * @param {String} inputId unique identifier of the combo box element which value to receive
+ * @returns a String value from the combo box element representing currently selected option
+ */
 function getEditedModeComboSelection(inputId) {
   const comboElement = document.querySelector(`div#mode-placeholder select#${inputId}`);
   if (comboElement === null) {

--- a/frontend/js/settings-tab-quiz.js
+++ b/frontend/js/settings-tab-quiz.js
@@ -536,7 +536,7 @@ function createSettingInputNumber(id, watch, labelText, initValue, minValue, max
  * @returns HTML code for select element with a label contained in a divider element
  */
 function createSettingInputCombo(id, watch, labelText, allValues, selectedValue) {
-  const emptyOption = `<option value="" disabled selected>select a supported language...</option>`;
+  const emptyOption = `<option value="" disabled selected hidden>select a supported language...</option>`;
   const options = Object.values(allValues)
     .map(option => {
       const selected = option === selectedValue ? "selected" : "";

--- a/frontend/js/settings-tab-quiz.js
+++ b/frontend/js/settings-tab-quiz.js
@@ -524,6 +524,16 @@ function createSettingInputNumber(id, watch, labelText, initValue, minValue, max
           </div>`;
 }
 
+function createSettingInputCombo(id, watch, labelText, allValues, comboValue) {
+  return `<div class="mode-setting-combo-box">
+            <label class="mode-setting-label" for="${id}">${labelText}</label>
+            <select id="${id}" class="mode-setting-combo" name="${id}">
+              <option value="en">en</option>
+              <option value="pl" selected>pl</option>
+            </select>
+          </div>`;
+}
+
 /**
  * Method used to create a single setting input of type language (flag checkboxes) with an appropriate label
  *

--- a/frontend/js/settings-tab-quiz.js
+++ b/frontend/js/settings-tab-quiz.js
@@ -242,7 +242,7 @@ function storeCurrentValuesInQuizMode(mode) {
                           + `max='${getEditedModeInputValue("questions-max")}'`;
           break;
         case "languages":
-          const defaultLanguage = getEditedModeInputValue("languages-default");
+          const defaultLanguage = getEditedModeComboSelection("languages-default");
           setting.label = getEditedModeInputValue("languages-label");
           setting.details = Object.values(SUPPORTED_LANGUAGES)
             .map((lang) => {
@@ -631,6 +631,14 @@ function getEditedModeInputValue(inputId) {
     throw `Element with ID "${inputId}" is not of type "text" nor "number".`;
   }
   return inputElement.value;
+}
+
+function getEditedModeComboSelection(inputId) {
+  const comboElement = document.querySelector(`div#mode-placeholder select#${inputId}`);
+  if (comboElement === null) {
+    throw `Element with ID "${inputId}" could not be found.`;
+  }
+  return comboElement.options[comboElement.selectedIndex].value;
 }
 
 /**

--- a/frontend/js/settings-tab-quiz.js
+++ b/frontend/js/settings-tab-quiz.js
@@ -479,7 +479,6 @@ function createContentQuestions(setting, watch) {
 function createContentLanguages(setting, watch) {
   const languageWithMark = setting.details.split(" ").find(el => el.indexOf(DEFAULT_LANGUAGE_MARK) > 0);
   const defaultLanguage = languageWithMark !== undefined ? languageWithMark.substring(0, languageWithMark.length - 1) : "";
-  console.log(setting.details);
   return createSettingInputText("languages-label", watch, "specify setting label", setting.label) +
          createSettingInputLanguage("languages-used", watch, "select supported languages", setting.details) +
          createSettingInputText("languages-default", watch, "specify default language", defaultLanguage);

--- a/frontend/js/settings-tab-quiz.js
+++ b/frontend/js/settings-tab-quiz.js
@@ -559,7 +559,7 @@ function createSettingComboOptions(allValues, selectedValue, noValuesText) {
   const options = Object.values(allValues)
     .map(option => {
       const selected = option === selectedValue ? "selected" : "";
-      return `<option value="${option}" ${selected}>${option}</option>`;
+      return `<option value="${option}" ${selected}>${option.toUpperCase()}</option>`;
     }).join("");
   return options.length > 0 ? options : emptyOption;
 }

--- a/frontend/js/settings-tab-quiz.js
+++ b/frontend/js/settings-tab-quiz.js
@@ -527,7 +527,7 @@ function createSettingInputNumber(id, watch, labelText, initValue, minValue, max
 function createSettingInputCombo(id, watch, labelText, allValues, comboValue) {
   return `<div class="mode-setting-combo-box">
             <label class="mode-setting-label" for="${id}">${labelText}</label>
-            <select id="${id}" class="mode-setting-combo" name="${id}">
+            <select id="${id}" class="mode-setting-combo" name="${id}" ${watch ? `onchange="updateCurrentlyEditedMode()"` : ``}>
               <option value="en">en</option>
               <option value="pl" selected>pl</option>
             </select>

--- a/frontend/js/settings-tab-quiz.js
+++ b/frontend/js/settings-tab-quiz.js
@@ -477,11 +477,12 @@ function createContentQuestions(setting, watch) {
  * @returns HTML code for collapsible quiz languages content
  */
 function createContentLanguages(setting, watch) {
-  const languageWithMark = setting.details.split(" ").find(el => el.indexOf(DEFAULT_LANGUAGE_MARK) > 0);
+  const selectedLanguages = setting.details.split(" ");
+  const languageWithMark = selectedLanguages.find(el => el.indexOf(DEFAULT_LANGUAGE_MARK) > 0);
   const defaultLanguage = languageWithMark !== undefined ? languageWithMark.substring(0, languageWithMark.length - 1) : "";
   return createSettingInputText("languages-label", watch, "specify setting label", setting.label) +
          createSettingInputLanguage("languages-used", watch, "select supported languages", setting.details) +
-         createSettingInputCombo("languages-default", watch, "specify default language", defaultLanguage);
+         createSettingInputCombo("languages-default", watch, "specify default language", selectedLanguages, defaultLanguage);
 }
 
 /**

--- a/frontend/js/settings-tab-quiz.js
+++ b/frontend/js/settings-tab-quiz.js
@@ -478,7 +478,7 @@ function createContentQuestions(setting, watch) {
  */
 function createContentLanguages(setting, watch) {
   const languageWithMark = setting.details.split(" ").find(el => el.indexOf(DEFAULT_LANGUAGE_MARK) > 0);
-  const defaultLanguage = languageWithMark !== undefined ? languageWithMark.substring(0, 2) : "";
+  const defaultLanguage = languageWithMark !== undefined ? languageWithMark.substring(0, languageWithMark.length - 1) : "";
   console.log(setting.details);
   return createSettingInputText("languages-label", watch, "specify setting label", setting.label) +
          createSettingInputLanguage("languages-used", watch, "select supported languages", setting.details) +

--- a/frontend/js/settings-tab-quiz.js
+++ b/frontend/js/settings-tab-quiz.js
@@ -536,18 +536,12 @@ function createSettingInputNumber(id, watch, labelText, initValue, minValue, max
  * @returns HTML code for select element with a label contained in a divider element
  */
 function createSettingInputCombo(id, watch, labelText, allValues, selectedValue) {
-  const emptyOption = `<option value="" disabled selected hidden>select a supported language...</option>`;
-  const options = Object.values(allValues)
-    .map(option => {
-      const selected = option === selectedValue ? "selected" : "";
-      return `<option value="${option}" ${selected}>${option}</option>`;
-    }).join("");
   return `<div class="mode-setting-combo-box">
             <label class="mode-setting-label" for="${id}">${labelText}</label>
             <select id="${id}" class="mode-setting-combo" name="${id}"
                                ${watch ? `onchange="updateCurrentlyEditedMode()"` : ``}
                                ${options.length === 0 ? "disabled" : ""}>
-              ${options.length > 0 ? options : emptyOption}
+              ${createSettingComboOptions(allValues, selectedValue, noValuesText)}
             </select>
           </div>`;
 }
@@ -612,6 +606,16 @@ function toggleFlagCheckbox(flagItem, watch) {
     linkedCheckbox.checked = !linkedCheckbox.checked;
     if (watch) {
       updateCurrentlyEditedMode();
+      // refresh the default language combo
+      const defaultLanguageCombo = document.querySelector("select#languages-default");
+      const currentLangageSetting = currentlyEditedMode.settings.find(setting => setting.type === "languages");
+      if (currentLangageSetting !== undefined && defaultLanguageCombo !== undefined) {
+        const selectedLanguages = currentLangageSetting.details.length > 0 ? currentLangageSetting.details.split(" ") : [];
+        const languageWithMark = selectedLanguages.find(el => el.indexOf(DEFAULT_LANGUAGE_MARK) > 0);
+        const defaultLanguage = languageWithMark !== undefined ? languageWithMark.substring(0, languageWithMark.length - 1) : "";
+        defaultLanguageCombo.disabled = currentLangageSetting.details.length === 0;
+        defaultLanguageCombo.innerHTML = createSettingComboOptions(selectedLanguages, defaultLanguage);
+      }
     }
   }
   flagItem.classList.toggle("flag-checked");

--- a/frontend/js/settings-tab-quiz.js
+++ b/frontend/js/settings-tab-quiz.js
@@ -481,7 +481,7 @@ function createContentLanguages(setting, watch) {
   const defaultLanguage = languageWithMark !== undefined ? languageWithMark.substring(0, languageWithMark.length - 1) : "";
   return createSettingInputText("languages-label", watch, "specify setting label", setting.label) +
          createSettingInputLanguage("languages-used", watch, "select supported languages", setting.details) +
-         createSettingInputText("languages-default", watch, "specify default language", defaultLanguage);
+         createSettingInputCombo("languages-default", watch, "specify default language", defaultLanguage);
 }
 
 /**

--- a/frontend/js/settings-tab-quiz.js
+++ b/frontend/js/settings-tab-quiz.js
@@ -534,6 +534,7 @@ function createSettingInputNumber(id, watch, labelText, initValue, minValue, max
  * @param {String} labelText the text displayed in a label
  * @param {String} allValues all combo box options to be displayed in select element
  * @param {String} selectedValue initial combo box selected option
+ * @param {String} noValuesText string displayed in a combo box when no options are available
  * @returns HTML code for select element with a label contained in a divider element
  */
 function createSettingInputCombo(id, watch, labelText, allValues, selectedValue, noValuesText) {
@@ -547,6 +548,14 @@ function createSettingInputCombo(id, watch, labelText, allValues, selectedValue,
           </div>`;
 }
 
+/**
+ * Method used to create select combo options content based on the all supported values and selected value
+ *
+ * @param {String} allValues all combo box options to be displayed in select element
+ * @param {String} selectedValue initial combo box selected option
+ * @param {String} noValuesText string displayed in a combo box when no options are available
+ * @returns HTML code for combo select options
+ */
 function createSettingComboOptions(allValues, selectedValue, noValuesText) {
   const emptyOption = `<option value="" disabled selected hidden>${noValuesText}</option>`;
   const options = Object.values(allValues)

--- a/frontend/js/settings-tab-quiz.js
+++ b/frontend/js/settings-tab-quiz.js
@@ -630,7 +630,10 @@ function toggleFlagCheckbox(flagItem, watch) {
 function parseLanguageDetails(details) {
   const selectedLanguages = details.length > 0 ? details.split(" ") : [];
   const languageWithMark = selectedLanguages.find(el => el.indexOf(DEFAULT_LANGUAGE_MARK) > 0);
-  const defaultLanguage = languageWithMark !== undefined ? languageWithMark.substring(0, languageWithMark.length - 1) : "";
+  const firstLanguage = selectedLanguages.length > 0 ? selectedLanguages[0] : "";
+  const defaultLanguage = languageWithMark !== undefined
+    ? languageWithMark.substring(0, languageWithMark.length - 1)
+    : firstLanguage;
   return { selected: selectedLanguages, default: defaultLanguage };
 }
 

--- a/frontend/js/settings-tab-quiz.js
+++ b/frontend/js/settings-tab-quiz.js
@@ -478,7 +478,8 @@ function createContentQuestions(setting, watch) {
  */
 function createContentLanguages(setting, watch) {
   return createSettingInputText("languages-label", watch, "specify setting label", setting.label) +
-         createSettingInputLanguage("languages-used", watch, "select supported languages", setting.details);
+         createSettingInputLanguage("languages-used", watch, "select supported languages", setting.details) +
+         createSettingInputText("languages-default", watch, "specify default language", "pl");
 }
 
 /**

--- a/frontend/js/settings-tab-quiz.js
+++ b/frontend/js/settings-tab-quiz.js
@@ -477,13 +477,11 @@ function createContentQuestions(setting, watch) {
  * @returns HTML code for collapsible quiz languages content
  */
 function createContentLanguages(setting, watch) {
-  const selectedLanguages = setting.details.length > 0 ? setting.details.split(" ") : [];
-  const languageWithMark = selectedLanguages.find(el => el.indexOf(DEFAULT_LANGUAGE_MARK) > 0);
-  const defaultLanguage = languageWithMark !== undefined ? languageWithMark.substring(0, languageWithMark.length - 1) : "";
+  const languages = parseLanguageDetails(setting.details);
   return createSettingInputText("languages-label", watch, "specify setting label", setting.label) +
          createSettingInputLanguage("languages-used", watch, "select supported languages", setting.details) +
-         createSettingInputCombo("languages-default", watch, "specify default language", selectedLanguages,
-                                                      defaultLanguage, "select a supported language...");
+         createSettingInputCombo("languages-default", watch, "specify default language", languages.selected,
+                                                      languages.default, "select a supported language...");
 }
 
 /**
@@ -620,11 +618,9 @@ function toggleFlagCheckbox(flagItem, watch) {
       const defaultLanguageCombo = document.querySelector("select#languages-default");
       const currentLangageSetting = currentlyEditedMode.settings.find(setting => setting.type === "languages");
       if (currentLangageSetting !== undefined && defaultLanguageCombo !== undefined) {
-        const selectedLanguages = currentLangageSetting.details.length > 0 ? currentLangageSetting.details.split(" ") : [];
-        const languageWithMark = selectedLanguages.find(el => el.indexOf(DEFAULT_LANGUAGE_MARK) > 0);
-        const defaultLanguage = languageWithMark !== undefined ? languageWithMark.substring(0, languageWithMark.length - 1) : "";
+        const languages = parseLanguageDetails(currentLangageSetting.details);
+        defaultLanguageCombo.innerHTML = createSettingComboOptions(languages.selected, languages.default, "select a supported language...");
         defaultLanguageCombo.disabled = currentLangageSetting.details.length === 0;
-        defaultLanguageCombo.innerHTML = createSettingComboOptions(selectedLanguages, defaultLanguage, "select a supported language...");
       }
     }
   }

--- a/frontend/js/settings-tab-quiz.js
+++ b/frontend/js/settings-tab-quiz.js
@@ -633,12 +633,9 @@ function parseLanguageDetails(details) {
   const languageDefault = languageMarked !== undefined
     ? languageMarked.substring(0, languageMarked.length - 1)
     : languageArray.length > 0 ? languageArray[0] : "";
-  const selectedLanguages = languageArray.map(lang => {
-    if (lang.indexOf(DEFAULT_LANGUAGE_MARK) > 0) {
-      return lang.substring(0, lang.length - 1);
-    }
-    return lang;
-  });
+  const selectedLanguages = languageArray.map((lang) =>
+    lang.indexOf(DEFAULT_LANGUAGE_MARK) > 0 ? lang.substring(0, lang.length - 1) : lang
+  );
   return { selected: selectedLanguages, default: languageDefault };
 }
 

--- a/frontend/js/settings-tab-quiz.js
+++ b/frontend/js/settings-tab-quiz.js
@@ -631,6 +631,13 @@ function toggleFlagCheckbox(flagItem, watch) {
   flagItem.classList.toggle("flag-checked");
 }
 
+function parseLanguageDetails(details) {
+  const selectedLanguages = details.length > 0 ? details.split(" ") : [];
+  const languageWithMark = selectedLanguages.find(el => el.indexOf(DEFAULT_LANGUAGE_MARK) > 0);
+  const defaultLanguage = languageWithMark !== undefined ? languageWithMark.substring(0, languageWithMark.length - 1) : "";
+  return { selected: selectedLanguages, default: defaultLanguage };
+}
+
 /**
  * Method used to create drop target placeholder
  *

--- a/frontend/js/settings-tab-quiz.js
+++ b/frontend/js/settings-tab-quiz.js
@@ -544,7 +544,9 @@ function createSettingInputCombo(id, watch, labelText, allValues, selectedValue)
     }).join("");
   return `<div class="mode-setting-combo-box">
             <label class="mode-setting-label" for="${id}">${labelText}</label>
-            <select id="${id}" class="mode-setting-combo" name="${id}" ${watch ? `onchange="updateCurrentlyEditedMode()"` : ``}>
+            <select id="${id}" class="mode-setting-combo" name="${id}"
+                               ${watch ? `onchange="updateCurrentlyEditedMode()"` : ``}
+                               ${options.length === 0 ? "disabled" : ""}>
               ${options.length > 0 ? options : emptyOption}
             </select>
           </div>`;

--- a/frontend/js/settings-tab-quiz.js
+++ b/frontend/js/settings-tab-quiz.js
@@ -628,12 +628,18 @@ function toggleFlagCheckbox(flagItem, watch) {
 }
 
 function parseLanguageDetails(details) {
-  const selectedLanguages = details.length > 0 ? details.split(" ") : [];
-  const languageWithMark = selectedLanguages.find(el => el.indexOf(DEFAULT_LANGUAGE_MARK) > 0);
-  const firstLanguage = selectedLanguages.length > 0 ? selectedLanguages[0] : "";
+  const languagesArray = details.length > 0 ? details.split(" ") : [];
+  const languageWithMark = languagesArray.find(el => el.indexOf(DEFAULT_LANGUAGE_MARK) > 0);
+  const firstLanguage = languagesArray.length > 0 ? languagesArray[0] : "";
   const defaultLanguage = languageWithMark !== undefined
     ? languageWithMark.substring(0, languageWithMark.length - 1)
     : firstLanguage;
+  const selectedLanguages = languagesArray.map(lang => {
+    if (lang.indexOf(DEFAULT_LANGUAGE_MARK) > 0) {
+      return lang.substring(0, lang.length - 1);
+    }
+    return lang;
+  });
   return { selected: selectedLanguages, default: defaultLanguage };
 }
 

--- a/frontend/js/settings-tab-quiz.js
+++ b/frontend/js/settings-tab-quiz.js
@@ -627,6 +627,12 @@ function toggleFlagCheckbox(flagItem, watch) {
   flagItem.classList.toggle("flag-checked");
 }
 
+/**
+ * Method used to parse language details
+ *
+ * @param {String} details of language settings stored in a backend service
+ * @returns object with selected languages and the default language
+ */
 function parseLanguageDetails(details) {
   const languageArray = details.length > 0 ? details.split(" ") : [];
   const languageMarked = languageArray.find(el => el.indexOf(DEFAULT_LANGUAGE_MARK) > 0);

--- a/frontend/js/settings-tab-quiz.js
+++ b/frontend/js/settings-tab-quiz.js
@@ -540,7 +540,7 @@ function createSettingInputCombo(id, watch, labelText, allValues, selectedValue)
             <label class="mode-setting-label" for="${id}">${labelText}</label>
             <select id="${id}" class="mode-setting-combo" name="${id}"
                                ${watch ? `onchange="updateCurrentlyEditedMode()"` : ``}
-                               ${options.length === 0 ? "disabled" : ""}>
+                               ${allValues.length === 0 ? "disabled" : ""}>
               ${createSettingComboOptions(allValues, selectedValue, noValuesText)}
             </select>
           </div>`;

--- a/frontend/js/settings-tab-quiz.js
+++ b/frontend/js/settings-tab-quiz.js
@@ -242,7 +242,7 @@ function storeCurrentValuesInQuizMode(mode) {
                           + `max='${getEditedModeInputValue("questions-max")}'`;
           break;
         case "languages":
-          const defaultLanguage = "pl";
+          const defaultLanguage = getEditedModeInputValue("languages-default");
           setting.label = getEditedModeInputValue("languages-label");
           setting.details = Object.values(SUPPORTED_LANGUAGES)
             .map((lang) => {

--- a/frontend/js/settings-tab-quiz.js
+++ b/frontend/js/settings-tab-quiz.js
@@ -1,5 +1,6 @@
 // the list of currently supported languages
 const SUPPORTED_LANGUAGES = ["de", "en", "es", "fr", "pl", "pt"];
+const DEFAULT_LANGUAGE_MARK = "!";
 // variables used by quiz modes tab in settings page
 var availableQuizModes = [];
 var availableModeSettings = [];
@@ -245,8 +246,8 @@ function storeCurrentValuesInQuizMode(mode) {
           setting.label = getEditedModeInputValue("languages-label");
           setting.details = Object.values(SUPPORTED_LANGUAGES)
             .map((lang) => {
-              const usedSeparator = defaultLanguage === lang ? "! " : " ";
-              return getEditedModeInputCheckState(`check-flag-${lang}`) ? lang + usedSeparator : "";
+              const languageMarker = defaultLanguage === lang ? DEFAULT_LANGUAGE_MARK : "";
+              return getEditedModeInputCheckState(`check-flag-${lang}`) ? lang + languageMarker + " " : "";
             }).join("").trim();
           break;
         default:

--- a/frontend/js/settings-tab-quiz.js
+++ b/frontend/js/settings-tab-quiz.js
@@ -536,6 +536,7 @@ function createSettingInputNumber(id, watch, labelText, initValue, minValue, max
  * @returns HTML code for select element with a label contained in a divider element
  */
 function createSettingInputCombo(id, watch, labelText, allValues, selectedValue) {
+  const emptyOption = `<option value="" disabled selected>select a supported language...</option>`;
   const options = Object.values(allValues)
     .map(option => {
       const selected = option === selectedValue ? "selected" : "";
@@ -544,8 +545,7 @@ function createSettingInputCombo(id, watch, labelText, allValues, selectedValue)
   return `<div class="mode-setting-combo-box">
             <label class="mode-setting-label" for="${id}">${labelText}</label>
             <select id="${id}" class="mode-setting-combo" name="${id}" ${watch ? `onchange="updateCurrentlyEditedMode()"` : ``}>
-              <option value="en">en</option>
-              <option value="pl" selected>pl</option>
+              ${options.length > 0 ? options : emptyOption}
             </select>
           </div>`;
 }

--- a/frontend/js/settings-tab-quiz.js
+++ b/frontend/js/settings-tab-quiz.js
@@ -482,7 +482,8 @@ function createContentLanguages(setting, watch) {
   const defaultLanguage = languageWithMark !== undefined ? languageWithMark.substring(0, languageWithMark.length - 1) : "";
   return createSettingInputText("languages-label", watch, "specify setting label", setting.label) +
          createSettingInputLanguage("languages-used", watch, "select supported languages", setting.details) +
-         createSettingInputCombo("languages-default", watch, "specify default language", selectedLanguages, defaultLanguage);
+         createSettingInputCombo("languages-default", watch, "specify default language", selectedLanguages,
+                                                      defaultLanguage, "select a supported language...");
 }
 
 /**
@@ -535,7 +536,7 @@ function createSettingInputNumber(id, watch, labelText, initValue, minValue, max
  * @param {String} selectedValue initial combo box selected option
  * @returns HTML code for select element with a label contained in a divider element
  */
-function createSettingInputCombo(id, watch, labelText, allValues, selectedValue) {
+function createSettingInputCombo(id, watch, labelText, allValues, selectedValue, noValuesText) {
   return `<div class="mode-setting-combo-box">
             <label class="mode-setting-label" for="${id}">${labelText}</label>
             <select id="${id}" class="mode-setting-combo" name="${id}"
@@ -546,8 +547,8 @@ function createSettingInputCombo(id, watch, labelText, allValues, selectedValue)
           </div>`;
 }
 
-function createSettingComboOptions(allValues, selectedValue) {
-  const emptyOption = `<option value="" disabled selected hidden>select a supported language...</option>`;
+function createSettingComboOptions(allValues, selectedValue, noValuesText) {
+  const emptyOption = `<option value="" disabled selected hidden>${noValuesText}</option>`;
   const options = Object.values(allValues)
     .map(option => {
       const selected = option === selectedValue ? "selected" : "";
@@ -614,7 +615,7 @@ function toggleFlagCheckbox(flagItem, watch) {
         const languageWithMark = selectedLanguages.find(el => el.indexOf(DEFAULT_LANGUAGE_MARK) > 0);
         const defaultLanguage = languageWithMark !== undefined ? languageWithMark.substring(0, languageWithMark.length - 1) : "";
         defaultLanguageCombo.disabled = currentLangageSetting.details.length === 0;
-        defaultLanguageCombo.innerHTML = createSettingComboOptions(selectedLanguages, defaultLanguage);
+        defaultLanguageCombo.innerHTML = createSettingComboOptions(selectedLanguages, defaultLanguage, "select a supported language...");
       }
     }
   }

--- a/frontend/js/settings-tab-quiz.js
+++ b/frontend/js/settings-tab-quiz.js
@@ -477,9 +477,12 @@ function createContentQuestions(setting, watch) {
  * @returns HTML code for collapsible quiz languages content
  */
 function createContentLanguages(setting, watch) {
+  const languageWithMark = setting.details.split(" ").find(el => el.indexOf(DEFAULT_LANGUAGE_MARK) > 0);
+  const defaultLanguage = (languageWithMark !== undefined ? languageWithMark : setting.details).substring(0, 2);
+  console.log(setting.details);
   return createSettingInputText("languages-label", watch, "specify setting label", setting.label) +
          createSettingInputLanguage("languages-used", watch, "select supported languages", setting.details) +
-         createSettingInputText("languages-default", watch, "specify default language", "pl");
+         createSettingInputText("languages-default", watch, "specify default language", defaultLanguage);
 }
 
 /**

--- a/frontend/js/settings-tab-quiz.js
+++ b/frontend/js/settings-tab-quiz.js
@@ -478,7 +478,7 @@ function createContentQuestions(setting, watch) {
  */
 function createContentLanguages(setting, watch) {
   const languageWithMark = setting.details.split(" ").find(el => el.indexOf(DEFAULT_LANGUAGE_MARK) > 0);
-  const defaultLanguage = (languageWithMark !== undefined ? languageWithMark : setting.details).substring(0, 2);
+  const defaultLanguage = languageWithMark !== undefined ? languageWithMark.substring(0, 2) : "";
   console.log(setting.details);
   return createSettingInputText("languages-label", watch, "specify setting label", setting.label) +
          createSettingInputLanguage("languages-used", watch, "select supported languages", setting.details) +

--- a/frontend/js/settings-tab-quiz.js
+++ b/frontend/js/settings-tab-quiz.js
@@ -477,7 +477,7 @@ function createContentQuestions(setting, watch) {
  * @returns HTML code for collapsible quiz languages content
  */
 function createContentLanguages(setting, watch) {
-  const selectedLanguages = setting.details.split(" ");
+  const selectedLanguages = setting.details.length > 0 ? setting.details.split(" ") : [];
   const languageWithMark = selectedLanguages.find(el => el.indexOf(DEFAULT_LANGUAGE_MARK) > 0);
   const defaultLanguage = languageWithMark !== undefined ? languageWithMark.substring(0, languageWithMark.length - 1) : "";
   return createSettingInputText("languages-label", watch, "specify setting label", setting.label) +

--- a/frontend/js/settings-tab-quiz.js
+++ b/frontend/js/settings-tab-quiz.js
@@ -531,8 +531,8 @@ function createSettingInputNumber(id, watch, labelText, initValue, minValue, max
  * @param {Integer} id unique identifier of the created select
  * @param {Boolean} watch flag used to indetify if we should watch select option change and update mode dirty state
  * @param {String} labelText the text displayed in a label
- * @param {Integer} allValues all combo box options to be displayed in select element
- * @param {Integer} selectedValue initial combo box selected option
+ * @param {String} allValues all combo box options to be displayed in select element
+ * @param {String} selectedValue initial combo box selected option
  * @returns HTML code for select element with a label contained in a divider element
  */
 function createSettingInputCombo(id, watch, labelText, allValues, selectedValue) {

--- a/frontend/js/settings-tab-quiz.js
+++ b/frontend/js/settings-tab-quiz.js
@@ -241,10 +241,13 @@ function storeCurrentValuesInQuizMode(mode) {
                           + `max='${getEditedModeInputValue("questions-max")}'`;
           break;
         case "languages":
+          const defaultLanguage = "pl";
           setting.label = getEditedModeInputValue("languages-label");
           setting.details = Object.values(SUPPORTED_LANGUAGES)
-            .map((lang) => getEditedModeInputCheckState(`check-flag-${lang}`) ? lang + " " : "")
-            .join("").trim();
+            .map((lang) => {
+              const usedSeparator = defaultLanguage === lang ? "! " : " ";
+              return getEditedModeInputCheckState(`check-flag-${lang}`) ? lang + usedSeparator : "";
+            }).join("").trim();
           break;
         default:
           throw `Unknown type: ${setting.type}`;


### PR DESCRIPTION
This patch fixes #52
Added new drop down list with currently selected languages. Thanks to that the user will be able to select the language which should be selected by default:
![image](https://user-images.githubusercontent.com/22420752/234368798-0c56a22a-a29d-4ee3-84ad-79a02b1103ef.png)
