### PR TITLE
Display toast popup after quiz mode change

### DIFF
--- a/frontend/css/settings.css
+++ b/frontend/css/settings.css
@@ -567,3 +567,23 @@ div#settings-placeholder > div.setting-box {
   font-size: 17px;
   font-family: var(--clear-font-primary), var(--clear-font-backup), Verdana, sans-serif;
 }
+
+#settings-changed-toast.information {
+  background-color: limegreen;
+  color: black;
+}
+
+#settings-changed-toast.warning {
+  background-color: darkorange;
+  color: black;
+}
+
+#settings-changed-toast.error {
+  background-color: red;
+  color: white;
+}
+
+#settings-changed-toast.fatal {
+  background-color: black;
+  color: white;
+}

--- a/frontend/css/settings.css
+++ b/frontend/css/settings.css
@@ -552,3 +552,18 @@ div#settings-placeholder {
 div#settings-placeholder > div.setting-box {
   margin-bottom: 5px;
 }
+
+#settings-changed-toast {
+  opacity: 0;
+  z-index: 100;
+  padding: 15px;
+  position: fixed;
+  left: 50%;
+  bottom: 50px;
+  min-width: 500px;
+  margin-left: -250px;
+  border-radius: 10px;
+  text-align: center;
+  font-size: 17px;
+  font-family: var(--clear-font-primary), var(--clear-font-backup), Verdana, sans-serif;
+}

--- a/frontend/css/settings.css
+++ b/frontend/css/settings.css
@@ -587,3 +587,33 @@ div#settings-placeholder > div.setting-box {
   background-color: black;
   color: white;
 }
+
+#settings-changed-toast.show {
+  animation: toast-fade 3s linear;
+}
+
+@keyframes toast-fade {
+  0%,
+  100% {
+    bottom: 0;
+    opacity: 0;
+  }
+  10%,
+  90% {
+    bottom: 50px;
+    opacity: 1;
+  }
+}
+
+@-webkit-keyframes toast-fade {
+  0%,
+  100% {
+    bottom: 0;
+    opacity: 0;
+  }
+  10%,
+  90% {
+    bottom: 50px;
+    opacity: 1;
+  }
+}

--- a/frontend/css/settings.css
+++ b/frontend/css/settings.css
@@ -76,6 +76,71 @@
   display: none;
 }
 
+#settings-changed-toast {
+  opacity: 0;
+  z-index: 100;
+  padding: 15px;
+  position: fixed;
+  left: 50%;
+  bottom: var(--toast-bottom-dist-px);
+  min-width: 500px;
+  margin-left: -250px;
+  border-radius: 10px;
+  text-align: center;
+  font-size: 17px;
+  font-family: var(--clear-font-primary), var(--clear-font-backup), Verdana, sans-serif;
+}
+
+#settings-changed-toast.information {
+  background-color: limegreen;
+  color: black;
+}
+
+#settings-changed-toast.warning {
+  background-color: darkorange;
+  color: black;
+}
+
+#settings-changed-toast.error {
+  background-color: red;
+  color: white;
+}
+
+#settings-changed-toast.fatal {
+  background-color: black;
+  color: white;
+}
+
+#settings-changed-toast.show {
+  animation: toast-fade 3s linear;
+}
+
+@keyframes toast-fade {
+  0%,
+  100% {
+    bottom: 0;
+    opacity: 0;
+  }
+  10%,
+  90% {
+    bottom: var(--toast-bottom-dist-px);
+    opacity: 1;
+  }
+}
+
+@-webkit-keyframes toast-fade {
+  0%,
+  100% {
+    bottom: 0;
+    opacity: 0;
+  }
+  10%,
+  90% {
+    bottom: var(--toast-bottom-dist-px);
+    opacity: 1;
+  }
+}
+
 /************************************/
 /* quiz modes tab - common          */
 /************************************/
@@ -552,69 +617,4 @@ div#settings-placeholder {
 
 div#settings-placeholder > div.setting-box {
   margin-bottom: 5px;
-}
-
-#settings-changed-toast {
-  opacity: 0;
-  z-index: 100;
-  padding: 15px;
-  position: fixed;
-  left: 50%;
-  bottom: var(--toast-bottom-dist-px);
-  min-width: 500px;
-  margin-left: -250px;
-  border-radius: 10px;
-  text-align: center;
-  font-size: 17px;
-  font-family: var(--clear-font-primary), var(--clear-font-backup), Verdana, sans-serif;
-}
-
-#settings-changed-toast.information {
-  background-color: limegreen;
-  color: black;
-}
-
-#settings-changed-toast.warning {
-  background-color: darkorange;
-  color: black;
-}
-
-#settings-changed-toast.error {
-  background-color: red;
-  color: white;
-}
-
-#settings-changed-toast.fatal {
-  background-color: black;
-  color: white;
-}
-
-#settings-changed-toast.show {
-  animation: toast-fade 3s linear;
-}
-
-@keyframes toast-fade {
-  0%,
-  100% {
-    bottom: 0;
-    opacity: 0;
-  }
-  10%,
-  90% {
-    bottom: var(--toast-bottom-dist-px);
-    opacity: 1;
-  }
-}
-
-@-webkit-keyframes toast-fade {
-  0%,
-  100% {
-    bottom: 0;
-    opacity: 0;
-  }
-  10%,
-  90% {
-    bottom: var(--toast-bottom-dist-px);
-    opacity: 1;
-  }
 }

--- a/frontend/css/settings.css
+++ b/frontend/css/settings.css
@@ -3,6 +3,7 @@
   --table-border-radius: 10px;
   --collapse-button-time: 0.1s;
   --collapse-content-time: 0.2s;
+  --toast-bottom-dist-px: 50px;
 }
 
 ::-webkit-scrollbar {
@@ -559,7 +560,7 @@ div#settings-placeholder > div.setting-box {
   padding: 15px;
   position: fixed;
   left: 50%;
-  bottom: 50px;
+  bottom: var(--toast-bottom-dist-px);
   min-width: 500px;
   margin-left: -250px;
   border-radius: 10px;
@@ -600,7 +601,7 @@ div#settings-placeholder > div.setting-box {
   }
   10%,
   90% {
-    bottom: 50px;
+    bottom: var(--toast-bottom-dist-px);
     opacity: 1;
   }
 }
@@ -613,7 +614,7 @@ div#settings-placeholder > div.setting-box {
   }
   10%,
   90% {
-    bottom: 50px;
+    bottom: var(--toast-bottom-dist-px);
     opacity: 1;
   }
 }

--- a/frontend/js/settings-tab-quiz.js
+++ b/frontend/js/settings-tab-quiz.js
@@ -9,23 +9,6 @@ var currentlyEditedMode = undefined;
 var currentlyExpandedState = new Map();
 var currentlyDraggedElement = undefined;
 
-function settingsChangeShowToast(type, message) {
-  console.log(message);
-  var wordToast = document.getElementById("settings-changed-toast");
-  if (wordToast === null) return;
-  if (SETTINGS_TOAST_INFO === type) {
-    wordToast.className = "information show";
-  } else if (SETTINGS_TOAST_WARNING === type) {
-    wordToast.className = "warning show";
-  } else if (SETTINGS_TOAST_ERROR === type) {
-    wordToast.className = "error show";
-  } else {
-    wordToast.className = "fatal show";
-  }
-  wordToast.innerHTML = message;
-  setTimeout(() => (wordToast.className = wordToast.className.replace("show", "")), toastTimeout);
-}
-
 /**
  * Method used to read all defined quiz modes from backend service and display them in the UI tab
  */

--- a/frontend/js/settings-tab-quiz.js
+++ b/frontend/js/settings-tab-quiz.js
@@ -1,11 +1,7 @@
 // the list of currently supported languages
 const SUPPORTED_LANGUAGES = ["de", "en", "es", "fr", "pl", "pt"];
 const DEFAULT_LANGUAGE_MARK = "!";
-const SETTINGS_TOAST_INFO = 0;
-const SETTINGS_TOAST_WARNING = 1;
-const SETTINGS_TOAST_ERROR = 2;
 // variables used by quiz modes tab in settings page
-var toastTimeout = 3000;
 var availableQuizModes = [];
 var availableModeSettings = [];
 var dirtyQuizModes = new Set();

--- a/frontend/js/settings-tab-quiz.js
+++ b/frontend/js/settings-tab-quiz.js
@@ -1,7 +1,11 @@
 // the list of currently supported languages
 const SUPPORTED_LANGUAGES = ["de", "en", "es", "fr", "pl", "pt"];
 const DEFAULT_LANGUAGE_MARK = "!";
+const SETTINGS_TOAST_INFO = 0;
+const SETTINGS_TOAST_WARNING = 1;
+const SETTINGS_TOAST_ERROR = 2;
 // variables used by quiz modes tab in settings page
+var toastTimeout = 3000;
 var availableQuizModes = [];
 var availableModeSettings = [];
 var dirtyQuizModes = new Set();

--- a/frontend/js/settings-tab-quiz.js
+++ b/frontend/js/settings-tab-quiz.js
@@ -36,7 +36,7 @@ function settingsChangeShowToast(type, message) {
 function initializeTabQuizModes() {
   getQuizModes((err, data) => {
     if (err) {
-      console.log("ERROR " + err.status + ": " + err.message);
+      settingsChangeShowToast(SETTINGS_TOAST_ERROR, "ERROR " + err.status + ": " + err.message);
     } else {
       availableQuizModes = data;
       updateQuizModesTable();
@@ -56,7 +56,7 @@ function initializeSettingsContent() {
   if (settingsPlaceholder === null) return;
   getModeSettings((err, data) => {
     if (err) {
-      console.log("ERROR " + err.status + ": " + err.message);
+      settingsChangeShowToast(SETTINGS_TOAST_ERROR, "ERROR " + err.status + ": " + err.message);
     } else {
       settingsPlaceholder.innerHTML = Object.values(data)
         .map((setting) => {
@@ -75,8 +75,9 @@ function initializeSettingsContent() {
 function createQuizMode() {
   postQuizMode((err, data) => {
     if (err) {
-      console.log("ERROR " + err.status + ": " + err.message);
+      settingsChangeShowToast(SETTINGS_TOAST_ERROR, "ERROR " + err.status + ": " + err.message);
     } else {
+      settingsChangeShowToast(SETTINGS_TOAST_INFO, "quiz mode added");
       availableQuizModes.push(data);
       updateQuizModesTable();
       selectMode(data.id);
@@ -96,9 +97,9 @@ function updateQuizMode() {
   }
   putQuizMode(currentlyEditedMode.id, currentlyEditedMode, (err, data) => {
     if (err) {
-      console.log("ERROR " + err.status + ": " + err.message);
+      settingsChangeShowToast(SETTINGS_TOAST_ERROR, "ERROR " + err.status + ": " + err.message);
     } else {
-      console.log(data);
+      settingsChangeShowToast(SETTINGS_TOAST_INFO, data);
       dirtyQuizModes.delete(currentlyEditedMode.id);
       // disable save button so the user cannot save changes
       updateSaveModeButtonEnableState(false);
@@ -116,9 +117,9 @@ function updateQuizMode() {
 function removeQuizMode(modeId) {
   deleteQuizMode(modeId, (err, data) => {
     if (err) {
-      console.log("ERROR " + err.status + ": " + err.message);
+      settingsChangeShowToast(SETTINGS_TOAST_ERROR, "ERROR " + err.status + ": " + err.message);
     } else {
-      console.log(data);
+      settingsChangeShowToast(SETTINGS_TOAST_INFO, data);
       availableQuizModes = availableQuizModes.filter(mode => mode.id !== modeId);
       // clean currently edited mode variable if user removes it
       if (currentlyEditedMode.id === modeId) {

--- a/frontend/js/settings-tab-quiz.js
+++ b/frontend/js/settings-tab-quiz.js
@@ -13,6 +13,23 @@ var currentlyEditedMode = undefined;
 var currentlyExpandedState = new Map();
 var currentlyDraggedElement = undefined;
 
+function settingsChangeShowToast(type, message) {
+  console.log(message);
+  var wordToast = document.getElementById("settings-changed-toast");
+  if (wordToast === null) return;
+  if (SETTINGS_TOAST_INFO === type) {
+    wordToast.className = "information show";
+  } else if (SETTINGS_TOAST_WARNING === type) {
+    wordToast.className = "warning show";
+  } else if (SETTINGS_TOAST_ERROR === type) {
+    wordToast.className = "error show";
+  } else {
+    wordToast.className = "fatal show";
+  }
+  wordToast.innerHTML = message;
+  setTimeout(() => (wordToast.className = wordToast.className.replace("show", "")), toastTimeout);
+}
+
 /**
  * Method used to read all defined quiz modes from backend service and display them in the UI tab
  */

--- a/frontend/js/settings.js
+++ b/frontend/js/settings.js
@@ -31,6 +31,12 @@ function selectTab(event, tabId) {
   }
 }
 
+/**
+ * Method used to show toast when user changed settings
+ *
+ * @param {Integer} type of toast to be displayed
+ * @param {String} message which should be displayed in toast
+ */
 function settingsChangeShowToast(type, message) {
   console.log(message);
   var wordToast = document.getElementById("settings-changed-toast");

--- a/frontend/js/settings.js
+++ b/frontend/js/settings.js
@@ -30,3 +30,20 @@ function selectTab(event, tabId) {
     tabContent[i].className = "tab-content" + (tabContent[i].id === tabId ? " visible" : "");
   }
 }
+
+function settingsChangeShowToast(type, message) {
+  console.log(message);
+  var wordToast = document.getElementById("settings-changed-toast");
+  if (wordToast === null) return;
+  if (SETTINGS_TOAST_INFO === type) {
+    wordToast.className = "information show";
+  } else if (SETTINGS_TOAST_WARNING === type) {
+    wordToast.className = "warning show";
+  } else if (SETTINGS_TOAST_ERROR === type) {
+    wordToast.className = "error show";
+  } else {
+    wordToast.className = "fatal show";
+  }
+  wordToast.innerHTML = message;
+  setTimeout(() => (wordToast.className = wordToast.className.replace("show", "")), toastTimeout);
+}

--- a/frontend/js/settings.js
+++ b/frontend/js/settings.js
@@ -1,3 +1,9 @@
+const SETTINGS_TOAST_INFO = 0;
+const SETTINGS_TOAST_WARNING = 1;
+const SETTINGS_TOAST_ERROR = 2;
+// variables used in settings page
+var toastTimeout = 3000;
+
 /**
  * Method used to initialize settings page (main entry point after loading settings.html)
  */

--- a/frontend/settings.html
+++ b/frontend/settings.html
@@ -66,6 +66,7 @@
         </div>
       </div>
     </div>
+    <div id="settings-changed-toast">WORD ADJUSTMENT CONFIRMATION</div>
     <!-- footer with author information and copyrights -->
     <footer class="no-select">developed with 💗 pnk @ 2022-2023 🖖</footer>
   </body>


### PR DESCRIPTION
This patch fixes #56 
Now after successful quiz mode change a green toast popup with an appropriate message appears on the screen for 3 seconds:
![image](https://user-images.githubusercontent.com/22420752/235315281-19c11df2-2658-4381-8c5f-8a333cfaa234.png)
The same is true for failed changes, but in this case the toast will have red background:
![image](https://user-images.githubusercontent.com/22420752/235315272-14738d3d-26aa-4416-bf28-383671b29f60.png)
