### PR TITLE
Added deprecation option to build and fixed all warnings

### DIFF
--- a/backend/service-quiz/.idea/scala_compiler.xml
+++ b/backend/service-quiz/.idea/scala_compiler.xml
@@ -8,6 +8,7 @@
     <profile name="sbt 1" modules="smart-words" />
     <profile name="sbt 2" modules="service-quiz">
       <option name="deprecationWarnings" value="true" />
+      <option name="featureWarnings" value="true" />
     </profile>
   </component>
 </project>

--- a/backend/service-quiz/.idea/scala_compiler.xml
+++ b/backend/service-quiz/.idea/scala_compiler.xml
@@ -2,11 +2,11 @@
 <project version="4">
   <component name="ScalaCompilerConfiguration">
     <option name="deprecationWarnings" value="true" />
+    <option name="featureWarnings" value="true" />
     <parameters>
       <parameter value="-deprecation" />
     </parameters>
-    <profile name="sbt 1" modules="smart-words" />
-    <profile name="sbt 2" modules="service-quiz">
+    <profile name="sbt" modules="service-quiz">
       <option name="deprecationWarnings" value="true" />
       <option name="featureWarnings" value="true" />
     </profile>

--- a/backend/service-quiz/.idea/scala_compiler.xml
+++ b/backend/service-quiz/.idea/scala_compiler.xml
@@ -5,6 +5,9 @@
     <parameters>
       <parameter value="-deprecation" />
     </parameters>
-    <profile name="sbt 1" modules="service-quiz,smart-words" />
+    <profile name="sbt 1" modules="smart-words" />
+    <profile name="sbt 2" modules="service-quiz">
+      <option name="deprecationWarnings" value="true" />
+    </profile>
   </component>
 </project>

--- a/backend/service-quiz/build.sbt
+++ b/backend/service-quiz/build.sbt
@@ -21,6 +21,8 @@ libraryDependencies ++= Seq(
   "org.scalatest"   %% "scalatest"           % ScalaTestVersion
 )
 
+scalacOptions += "-deprecation"
+
 run := Defaults
   .runTask(
     Runtime / fullClasspath,

--- a/backend/service-quiz/build.sbt
+++ b/backend/service-quiz/build.sbt
@@ -21,7 +21,7 @@ libraryDependencies ++= Seq(
   "org.scalatest"   %% "scalatest"           % ScalaTestVersion
 )
 
-scalacOptions += "-deprecation"
+scalacOptions ++= Seq("-deprecation", "-feature")
 
 run := Defaults
   .runTask(

--- a/backend/service-quiz/src/main/scala/pl/smtc/smartwords/database/ModeDatabase.scala
+++ b/backend/service-quiz/src/main/scala/pl/smtc/smartwords/database/ModeDatabase.scala
@@ -29,7 +29,7 @@ class ModeDatabase(databaseFile: String = "modes.json") {
     var result: Boolean = false
     val modesFile: File = new File(resourceDir.resolve(databaseFile).toString)
     Using(new BufferedInputStream(new FileInputStream(modesFile))) { fileStream =>
-      val lines = Source.fromInputStream(fileStream).getLines.mkString.stripMargin
+      val lines = Source.fromInputStream(fileStream).getLines().mkString.stripMargin
       decode[List[Mode]](lines) match {
         case Right(modes) =>
           modes.foreach(mode => quizModes += mode)

--- a/backend/service-quiz/src/test/scala/pl/smtc/smartwords/client/WordServiceTest.scala
+++ b/backend/service-quiz/src/test/scala/pl/smtc/smartwords/client/WordServiceTest.scala
@@ -15,7 +15,7 @@ class WordServiceTest(alive: Boolean = true, wordFail: Boolean = false, category
     if (wordFail) {
       throw new WordServiceException("Invalid input parameter(s) - getRandomWord error!")
     }
-    val randomIdString: String = new Random().nextInt.toString
+    val randomIdString: String = Random.nextInt().toString
     val randomWordName: String = "word-" + language + "-" + mode.toString + randomIdString
     Word(randomWordName, "verb", List("definition-main-" + randomIdString, "alternate-definition-" + randomIdString))
   }

--- a/backend/service-quiz/src/test/scala/pl/smtc/smartwords/controller/HealthControllerTest.scala
+++ b/backend/service-quiz/src/test/scala/pl/smtc/smartwords/controller/HealthControllerTest.scala
@@ -22,6 +22,6 @@ class HealthControllerTest extends AnyFunSuite {
     val response: Option[Response[IO]] = controllerUnderTest.getRoutes.run(request).value.unsafeRunSync()
     val actualStatus: Status = response.get.status
     assert(actualStatus === Status.Ok)
-    assert(response.get.as[String].unsafeRunSync === "Service: QUIZ - status: OK")
+    assert(response.get.as[String].unsafeRunSync() === "Service: QUIZ - status: OK")
   }
 }

--- a/backend/service-quiz/src/test/scala/pl/smtc/smartwords/controller/ModeControllerTest.scala
+++ b/backend/service-quiz/src/test/scala/pl/smtc/smartwords/controller/ModeControllerTest.scala
@@ -119,7 +119,7 @@ class ModeControllerTest extends AnyFunSuite with BeforeAndAfterAll {
 
   test("testGetRoutesReturnsOkStatusWhenUpdatingExistingModeRequest") {
     val modeDatabase: ModeDatabase = new ModeDatabase("test-mode-controller-crud.json")
-    assert(modeDatabase.loadDatabase())
+    modeDatabase.loadDatabase()
     val controllerUnderTest: ModeController = new ModeController(modeDatabase)
     val endpoint: String = s"/0"
     val requestBody: Json =
@@ -139,7 +139,7 @@ class ModeControllerTest extends AnyFunSuite with BeforeAndAfterAll {
 
   test("testGetRoutesReturnsNotFoundWhenUpdatingNotExistingModeRequest") {
     val modeDatabase: ModeDatabase = new ModeDatabase("test-mode-controller-crud.json")
-    assert(modeDatabase.loadDatabase())
+    modeDatabase.loadDatabase()
     val controllerUnderTest: ModeController = new ModeController(modeDatabase)
     val endpoint: String = s"/100"
     val requestBody: Json =
@@ -160,7 +160,7 @@ class ModeControllerTest extends AnyFunSuite with BeforeAndAfterAll {
 
   test("testGetRoutesReturnsNotFoundWhenUpdatingNotDeletableModeRequest") {
     val modeDatabase: ModeDatabase = new ModeDatabase("test-mode-controller-crud.json")
-    assert(modeDatabase.loadDatabase())
+    modeDatabase.loadDatabase()
     val mode: Mode = modeDatabase.addMode()
     mode.deletable = false
     val controllerUnderTest: ModeController = new ModeController(modeDatabase)
@@ -183,7 +183,7 @@ class ModeControllerTest extends AnyFunSuite with BeforeAndAfterAll {
 
   test("testGetRoutesReturnsNothingWhenUpdatingModeWithInvalidId") {
     val modeDatabase: ModeDatabase = new ModeDatabase("test-mode-controller-crud.json")
-    assert(modeDatabase.loadDatabase())
+    modeDatabase.loadDatabase()
     val controllerUnderTest: ModeController = new ModeController(modeDatabase)
     val endpoint: String = s"/abc"
     val requestBody: Json =
@@ -198,7 +198,7 @@ class ModeControllerTest extends AnyFunSuite with BeforeAndAfterAll {
 
   test("testGetRoutesThrowsWhenUpdatingExistingModeRequestWithInvalidJsonBody") {
     val modeDatabase: ModeDatabase = new ModeDatabase("test-mode-controller-crud.json")
-    assert(modeDatabase.loadDatabase())
+    modeDatabase.loadDatabase()
     val controllerUnderTest: ModeController = new ModeController(modeDatabase)
     val endpoint: String = s"/0"
     val requestBody: Json = json"""{ "id" : 99, "name" : "UNIT test QUIZ mode 1", "deletable" : false }"""
@@ -208,7 +208,7 @@ class ModeControllerTest extends AnyFunSuite with BeforeAndAfterAll {
 
   test("testGetRoutesReturnsOkStatusWhenDeletingExistingModeRequest") {
     val modeDatabase: ModeDatabase = new ModeDatabase("test-mode-controller-crud.json")
-    assert(modeDatabase.loadDatabase())
+    modeDatabase.loadDatabase()
     val mode: Mode = modeDatabase.addMode()
     val controllerUnderTest: ModeController = new ModeController(modeDatabase)
     val endpoint: String = s"/${mode.id}"
@@ -222,7 +222,7 @@ class ModeControllerTest extends AnyFunSuite with BeforeAndAfterAll {
 
   test("testGetRoutesReturnsNotFoundWhenDeletingNotExistingModeRequest") {
     val modeDatabase: ModeDatabase = new ModeDatabase("test-mode-controller-crud.json")
-    assert(modeDatabase.loadDatabase())
+    modeDatabase.loadDatabase()
     val controllerUnderTest: ModeController = new ModeController(modeDatabase)
     val endpoint: String = s"/100"
     val request: Request[IO] = Request(Method.DELETE, Uri.unsafeFromString(endpoint))
@@ -235,7 +235,7 @@ class ModeControllerTest extends AnyFunSuite with BeforeAndAfterAll {
 
   test("testGetRoutesReturnsNotFoundWhenDeletingNotDeletableModeRequest") {
     val modeDatabase: ModeDatabase = new ModeDatabase("test-mode-controller-crud.json")
-    assert(modeDatabase.loadDatabase())
+    modeDatabase.loadDatabase()
     val mode: Mode = modeDatabase.addMode()
     mode.deletable = false
     val controllerUnderTest: ModeController = new ModeController(modeDatabase)
@@ -250,7 +250,7 @@ class ModeControllerTest extends AnyFunSuite with BeforeAndAfterAll {
 
   test("testGetRoutesReturnsNothingWhenDeletingModeWithInvalidId") {
     val modeDatabase: ModeDatabase = new ModeDatabase("test-mode-controller-crud.json")
-    assert(modeDatabase.loadDatabase())
+    modeDatabase.loadDatabase()
     val controllerUnderTest: ModeController = new ModeController(modeDatabase)
     val endpoint: String = s"/abc"
     val request: Request[IO] = Request(Method.DELETE, Uri.unsafeFromString(endpoint))

--- a/backend/service-quiz/src/test/scala/pl/smtc/smartwords/controller/ModeControllerTest.scala
+++ b/backend/service-quiz/src/test/scala/pl/smtc/smartwords/controller/ModeControllerTest.scala
@@ -58,7 +58,7 @@ class ModeControllerTest extends AnyFunSuite with BeforeAndAfterAll {
                  ]
                }
              ]"""
-    assert(response.get.as[Json].unsafeRunSync === expected)
+    assert(response.get.as[Json].unsafeRunSync() === expected)
   }
 
   test("testGetRoutesReturnsOkStatusAndEmptyBodyWhenGetModesRequestAndNoDatabaseInit") {
@@ -70,7 +70,7 @@ class ModeControllerTest extends AnyFunSuite with BeforeAndAfterAll {
     assert(response.nonEmpty)
     val actualStatus: Status = response.get.status
     assert(actualStatus === Status.Ok)
-    assert(response.get.as[Json].unsafeRunSync === json"""[]""")
+    assert(response.get.as[Json].unsafeRunSync() === json"""[]""")
   }
 
   test("testGetRoutesReturnsOkResponseWhenGetSupportedSettingsRequest") {
@@ -86,7 +86,7 @@ class ModeControllerTest extends AnyFunSuite with BeforeAndAfterAll {
     val expected: Json =
       json"""[ { "type" : "questions", "label" : "", "details" : "" },
                { "type" : "languages", "label" : "", "details" : "" } ]"""
-    assert(response.get.as[Json].unsafeRunSync === expected)
+    assert(response.get.as[Json].unsafeRunSync() === expected)
   }
 
   test("testGetRoutesReturnsOkStatusEvenWhenGetSupportedSettingsRequestAndNoDatabaseInit") {
@@ -101,7 +101,7 @@ class ModeControllerTest extends AnyFunSuite with BeforeAndAfterAll {
     val expected: Json =
       json"""[ { "type" : "questions", "label" : "", "details" : "" },
                { "type" : "languages", "label" : "", "details" : "" } ]"""
-    assert(response.get.as[Json].unsafeRunSync === expected)
+    assert(response.get.as[Json].unsafeRunSync() === expected)
   }
 
   test("testGetRoutesReturnsOkStatusWhenAddingNewModesRequest") {
@@ -114,7 +114,7 @@ class ModeControllerTest extends AnyFunSuite with BeforeAndAfterAll {
     val actualStatus: Status = response.get.status
     assert(actualStatus === Status.Ok)
     val expected: Json =json"""{ "id" : 0, "name" : "", "description" : "", "deletable" : true, "settings" : [] }"""
-    assert(response.get.as[Json].unsafeRunSync === expected)
+    assert(response.get.as[Json].unsafeRunSync() === expected)
   }
 
   test("testGetRoutesReturnsOkStatusWhenUpdatingExistingModeRequest") {
@@ -134,7 +134,7 @@ class ModeControllerTest extends AnyFunSuite with BeforeAndAfterAll {
     assert(response.nonEmpty)
     val actualStatus: Status = response.get.status
     assert(actualStatus === Status.Ok)
-    assert(response.get.as[String].unsafeRunSync === "Updated quiz mode ID: 0")
+    assert(response.get.as[String].unsafeRunSync() === "Updated quiz mode ID: 0")
   }
 
   test("testGetRoutesReturnsNotFoundWhenUpdatingNotExistingModeRequest") {
@@ -155,7 +155,7 @@ class ModeControllerTest extends AnyFunSuite with BeforeAndAfterAll {
     val actualStatus: Status = response.get.status
     assert(actualStatus === Status.NotFound)
     val expected: String = "Cannot find mode with ID: 100, or mode cannot be updated with initial settings removal"
-    assert(response.get.as[String].unsafeRunSync === expected)
+    assert(response.get.as[String].unsafeRunSync() === expected)
   }
 
   test("testGetRoutesReturnsNotFoundWhenUpdatingNotDeletableModeRequest") {
@@ -178,7 +178,7 @@ class ModeControllerTest extends AnyFunSuite with BeforeAndAfterAll {
     val actualStatus: Status = response.get.status
     assert(actualStatus === Status.NotFound)
     val expected: String = s"Cannot find mode with ID: ${mode.id}, or mode cannot be updated with initial settings removal"
-    assert(response.get.as[String].unsafeRunSync === expected)
+    assert(response.get.as[String].unsafeRunSync() === expected)
   }
 
   test("testGetRoutesReturnsNothingWhenUpdatingModeWithInvalidId") {
@@ -217,7 +217,7 @@ class ModeControllerTest extends AnyFunSuite with BeforeAndAfterAll {
     assert(response.nonEmpty)
     val actualStatus: Status = response.get.status
     assert(actualStatus === Status.Ok)
-    assert(response.get.as[String].unsafeRunSync === s"Deleted quiz mode ID: ${mode.id}")
+    assert(response.get.as[String].unsafeRunSync() === s"Deleted quiz mode ID: ${mode.id}")
   }
 
   test("testGetRoutesReturnsNotFoundWhenDeletingNotExistingModeRequest") {
@@ -230,7 +230,7 @@ class ModeControllerTest extends AnyFunSuite with BeforeAndAfterAll {
     assert(response.nonEmpty)
     val actualStatus: Status = response.get.status
     assert(actualStatus === Status.NotFound)
-    assert(response.get.as[String].unsafeRunSync === s"Cannot find mode with ID: 100, or mode is not deletable")
+    assert(response.get.as[String].unsafeRunSync() === s"Cannot find mode with ID: 100, or mode is not deletable")
   }
 
   test("testGetRoutesReturnsNotFoundWhenDeletingNotDeletableModeRequest") {
@@ -245,7 +245,7 @@ class ModeControllerTest extends AnyFunSuite with BeforeAndAfterAll {
     assert(response.nonEmpty)
     val actualStatus: Status = response.get.status
     assert(actualStatus === Status.NotFound)
-    assert(response.get.as[String].unsafeRunSync === s"Cannot find mode with ID: ${mode.id}, or mode is not deletable")
+    assert(response.get.as[String].unsafeRunSync() === s"Cannot find mode with ID: ${mode.id}, or mode is not deletable")
   }
 
   test("testGetRoutesReturnsNothingWhenDeletingModeWithInvalidId") {

--- a/backend/service-quiz/src/test/scala/pl/smtc/smartwords/controller/ModeControllerTest.scala
+++ b/backend/service-quiz/src/test/scala/pl/smtc/smartwords/controller/ModeControllerTest.scala
@@ -91,6 +91,7 @@ class ModeControllerTest extends AnyFunSuite with BeforeAndAfterAll {
 
   test("testGetRoutesReturnsOkStatusEvenWhenGetSupportedSettingsRequestAndNoDatabaseInit") {
     val modeDatabase: ModeDatabase = new ModeDatabase("test-mode-database-load.json")
+    assert(modeDatabase.loadDatabase())
     val controllerUnderTest: ModeController = new ModeController(modeDatabase)
     val endpoint: String = s"/settings"
     val request: Request[IO] = Request(Method.GET, Uri.unsafeFromString(endpoint))

--- a/backend/service-quiz/src/test/scala/pl/smtc/smartwords/controller/QuizControllerTest.scala
+++ b/backend/service-quiz/src/test/scala/pl/smtc/smartwords/controller/QuizControllerTest.scala
@@ -35,7 +35,7 @@ class QuizControllerTest extends AnyFunSuite {
     assert(response.nonEmpty)
     val actualStatus: Status = response.get.status
     assert(actualStatus === Status.Ok)
-    val actualBody: String = response.get.as[String].unsafeRunSync
+    val actualBody: String = response.get.as[String].unsafeRunSync()
     assert(actualBody.matches(uuidRegex))
   }
 
@@ -49,7 +49,7 @@ class QuizControllerTest extends AnyFunSuite {
     assert(response.nonEmpty)
     val actualStatus: Status = response.get.status
     assert(actualStatus === Status.Ok)
-    val actualBody: String = response.get.as[String].unsafeRunSync
+    val actualBody: String = response.get.as[String].unsafeRunSync()
     assert(actualBody.matches(uuidRegex))
   }
 
@@ -63,7 +63,7 @@ class QuizControllerTest extends AnyFunSuite {
     assert(response.nonEmpty)
     val actualStatus: Status = response.get.status
     assert(actualStatus === Status.ServiceUnavailable)
-    val actualBody: String = response.get.as[String].unsafeRunSync
+    val actualBody: String = response.get.as[String].unsafeRunSync()
     assert(actualBody === "Cannot start quiz. Service: WORD - not available.")
   }
 
@@ -77,7 +77,7 @@ class QuizControllerTest extends AnyFunSuite {
     assert(response.nonEmpty)
     val actualStatus: Status = response.get.status
     assert(actualStatus === Status.BadRequest)
-    val actualBody: String = response.get.as[String].unsafeRunSync
+    val actualBody: String = response.get.as[String].unsafeRunSync()
     assert(actualBody === "Cannot start quiz: Invalid input parameter(s) - getRandomWord error!")
   }
 
@@ -91,7 +91,7 @@ class QuizControllerTest extends AnyFunSuite {
     assert(response.nonEmpty)
     val actualStatus: Status = response.get.status
     assert(actualStatus === Status.BadRequest)
-    val actualBody: String = response.get.as[String].unsafeRunSync
+    val actualBody: String = response.get.as[String].unsafeRunSync()
     assert(actualBody === "Cannot start quiz: Invalid input parameter(s) - getWordsByCategory error!")
   }
 
@@ -101,14 +101,14 @@ class QuizControllerTest extends AnyFunSuite {
     val controllerUnderTest: QuizController = new QuizController(quizDatabase, wordService)
     val quizUuid: String = controllerUnderTest.getRoutes.run(Request(Method.POST, Uri.unsafeFromString(s"/start")))
                                                         .value.unsafeRunSync()
-                                                        .get.as[String].unsafeRunSync
+                                                        .get.as[String].unsafeRunSync()
     val endpoint: String = s"/${UUID.fromString(quizUuid)}/question/1"
     val request: Request[IO] = Request(Method.GET, Uri.unsafeFromString(endpoint))
     val response: Option[Response[IO]] = controllerUnderTest.getRoutes.run(request).value.unsafeRunSync()
     assert(response.nonEmpty)
     val actualStatus: Status = response.get.status
     assert(actualStatus === Status.Ok)
-    val actualBody: Json = response.get.as[Json].unsafeRunSync
+    val actualBody: Json = response.get.as[Json].unsafeRunSync()
     assert(actualBody.hcursor.downField("word").as[String] match {
       case Right(s) => s.startsWith("word-pl")
       case Left(_) => false
@@ -125,7 +125,7 @@ class QuizControllerTest extends AnyFunSuite {
     assert(response.nonEmpty)
     val actualStatus: Status = response.get.status
     assert(actualStatus === Status.NotFound)
-    val actualBody: String = response.get.as[String].unsafeRunSync
+    val actualBody: String = response.get.as[String].unsafeRunSync()
     assert(actualBody === "Specified quiz does not exist")
   }
 
@@ -135,14 +135,14 @@ class QuizControllerTest extends AnyFunSuite {
     val controllerUnderTest: QuizController = new QuizController(quizDatabase, wordService)
     val quizUuid: String = controllerUnderTest.getRoutes.run(Request(Method.POST, Uri.unsafeFromString(s"/start")))
                                                         .value.unsafeRunSync()
-                                                        .get.as[String].unsafeRunSync
+                                                        .get.as[String].unsafeRunSync()
     val endpoint: String = s"/${UUID.fromString(quizUuid)}/question/abc"
     val request: Request[IO] = Request(Method.GET, Uri.unsafeFromString(endpoint))
     val response: Option[Response[IO]] = controllerUnderTest.getRoutes.run(request).value.unsafeRunSync()
     assert(response.nonEmpty)
     val actualStatus: Status = response.get.status
     assert(actualStatus === Status.BadRequest)
-    val actualBody: String = response.get.as[String].unsafeRunSync
+    val actualBody: String = response.get.as[String].unsafeRunSync()
     assert(actualBody === "Question number must be of integer type.")
   }
 
@@ -152,14 +152,14 @@ class QuizControllerTest extends AnyFunSuite {
     val controllerUnderTest: QuizController = new QuizController(quizDatabase, wordService)
     val quizUuid: String = controllerUnderTest.getRoutes.run(Request(Method.POST, Uri.unsafeFromString(s"/start")))
                                                         .value.unsafeRunSync()
-                                                        .get.as[String].unsafeRunSync
+                                                        .get.as[String].unsafeRunSync()
     val endpoint: String = s"/${UUID.fromString(quizUuid)}/question/10"
     val request: Request[IO] = Request(Method.GET, Uri.unsafeFromString(endpoint))
     val response: Option[Response[IO]] = controllerUnderTest.getRoutes.run(request).value.unsafeRunSync()
     assert(response.nonEmpty)
     val actualStatus: Status = response.get.status
     assert(actualStatus === Status.BadRequest)
-    val actualBody: String = response.get.as[String].unsafeRunSync
+    val actualBody: String = response.get.as[String].unsafeRunSync()
     assert(actualBody === "Question number must have value between 0-9")
   }
 
@@ -169,14 +169,14 @@ class QuizControllerTest extends AnyFunSuite {
     val controllerUnderTest: QuizController = new QuizController(quizDatabase, wordService)
     val quizUuid: String = controllerUnderTest.getRoutes.run(Request(Method.POST, Uri.unsafeFromString(s"/start")))
                                                         .value.unsafeRunSync()
-                                                        .get.as[String].unsafeRunSync
+                                                        .get.as[String].unsafeRunSync()
     val endpoint: String = s"/${UUID.fromString(quizUuid)}/question/0/1"
     val request: Request[IO] = Request(Method.POST, Uri.unsafeFromString(endpoint))
     val response: Option[Response[IO]] = controllerUnderTest.getRoutes.run(request).value.unsafeRunSync()
     assert(response.nonEmpty)
     val actualStatus: Status = response.get.status
     assert(actualStatus === Status.Ok)
-    val actualBody: String = response.get.as[String].unsafeRunSync
+    val actualBody: String = response.get.as[String].unsafeRunSync()
     assert(actualBody === "false" || actualBody === "true")
   }
 
@@ -190,7 +190,7 @@ class QuizControllerTest extends AnyFunSuite {
     assert(response.nonEmpty)
     val actualStatus: Status = response.get.status
     assert(actualStatus === Status.NotFound)
-    val actualBody: String = response.get.as[String].unsafeRunSync
+    val actualBody: String = response.get.as[String].unsafeRunSync()
     assert(actualBody === "Specified quiz does not exist")
   }
 
@@ -200,14 +200,14 @@ class QuizControllerTest extends AnyFunSuite {
     val controllerUnderTest: QuizController = new QuizController(quizDatabase, wordService)
     val quizUuid: String = controllerUnderTest.getRoutes.run(Request(Method.POST, Uri.unsafeFromString(s"/start")))
                                                         .value.unsafeRunSync()
-                                                        .get.as[String].unsafeRunSync
+                                                        .get.as[String].unsafeRunSync()
     val endpoint: String = s"/${UUID.fromString(quizUuid)}/question/abc/0"
     val request: Request[IO] = Request(Method.POST, Uri.unsafeFromString(endpoint))
     val response: Option[Response[IO]] = controllerUnderTest.getRoutes.run(request).value.unsafeRunSync()
     assert(response.nonEmpty)
     val actualStatus: Status = response.get.status
     assert(actualStatus === Status.BadRequest)
-    val actualBody: String = response.get.as[String].unsafeRunSync
+    val actualBody: String = response.get.as[String].unsafeRunSync()
     assert(actualBody === "Question and answer number must be of integer type.")
   }
 
@@ -217,14 +217,14 @@ class QuizControllerTest extends AnyFunSuite {
     val controllerUnderTest: QuizController = new QuizController(quizDatabase, wordService)
     val quizUuid: String = controllerUnderTest.getRoutes.run(Request(Method.POST, Uri.unsafeFromString(s"/start")))
                                                         .value.unsafeRunSync()
-                                                        .get.as[String].unsafeRunSync
+                                                        .get.as[String].unsafeRunSync()
     val endpoint: String = s"/${UUID.fromString(quizUuid)}/question/0/abc"
     val request: Request[IO] = Request(Method.POST, Uri.unsafeFromString(endpoint))
     val response: Option[Response[IO]] = controllerUnderTest.getRoutes.run(request).value.unsafeRunSync()
     assert(response.nonEmpty)
     val actualStatus: Status = response.get.status
     assert(actualStatus === Status.BadRequest)
-    val actualBody: String = response.get.as[String].unsafeRunSync
+    val actualBody: String = response.get.as[String].unsafeRunSync()
     assert(actualBody === "Question and answer number must be of integer type.")
   }
 
@@ -234,14 +234,14 @@ class QuizControllerTest extends AnyFunSuite {
     val controllerUnderTest: QuizController = new QuizController(quizDatabase, wordService)
     val quizUuid: String = controllerUnderTest.getRoutes.run(Request(Method.POST, Uri.unsafeFromString(s"/start")))
                                                         .value.unsafeRunSync()
-                                                        .get.as[String].unsafeRunSync
+                                                        .get.as[String].unsafeRunSync()
     val endpoint: String = s"/${UUID.fromString(quizUuid)}/question/10/1"
     val request: Request[IO] = Request(Method.POST, Uri.unsafeFromString(endpoint))
     val response: Option[Response[IO]] = controllerUnderTest.getRoutes.run(request).value.unsafeRunSync()
     assert(response.nonEmpty)
     val actualStatus: Status = response.get.status
     assert(actualStatus === Status.BadRequest)
-    val actualBody: String = response.get.as[String].unsafeRunSync
+    val actualBody: String = response.get.as[String].unsafeRunSync()
     assert(actualBody === "Question number must have value between 0-9")
   }
 
@@ -251,14 +251,14 @@ class QuizControllerTest extends AnyFunSuite {
     val controllerUnderTest: QuizController = new QuizController(quizDatabase, wordService)
     val quizUuid: String = controllerUnderTest.getRoutes.run(Request(Method.POST, Uri.unsafeFromString(s"/start")))
                                                         .value.unsafeRunSync()
-                                                        .get.as[String].unsafeRunSync
+                                                        .get.as[String].unsafeRunSync()
     val endpoint: String = s"/${UUID.fromString(quizUuid)}/question/9/5"
     val request: Request[IO] = Request(Method.POST, Uri.unsafeFromString(endpoint))
     val response: Option[Response[IO]] = controllerUnderTest.getRoutes.run(request).value.unsafeRunSync()
     assert(response.nonEmpty)
     val actualStatus: Status = response.get.status
     assert(actualStatus === Status.BadRequest)
-    val actualBody: String = response.get.as[String].unsafeRunSync
+    val actualBody: String = response.get.as[String].unsafeRunSync()
     assert(actualBody === "Answer number must have value between 0-3")
   }
 
@@ -268,14 +268,14 @@ class QuizControllerTest extends AnyFunSuite {
     val controllerUnderTest: QuizController = new QuizController(quizDatabase, wordService)
     val quizUuid: String = controllerUnderTest.getRoutes.run(Request(Method.POST, Uri.unsafeFromString(s"/start")))
                                                         .value.unsafeRunSync()
-                                                        .get.as[String].unsafeRunSync
+                                                        .get.as[String].unsafeRunSync()
     val endpoint: String = s"/${UUID.fromString(quizUuid)}/stop"
     val request: Request[IO] = Request(Method.GET, Uri.unsafeFromString(endpoint))
     val response: Option[Response[IO]] = controllerUnderTest.getRoutes.run(request).value.unsafeRunSync()
     assert(response.nonEmpty)
     val actualStatus: Status = response.get.status
     assert(actualStatus === Status.Ok)
-    val actualBody: String = response.get.as[String].unsafeRunSync
+    val actualBody: String = response.get.as[String].unsafeRunSync()
     assert(actualBody === "0.0")
   }
 
@@ -289,7 +289,7 @@ class QuizControllerTest extends AnyFunSuite {
     assert(response.nonEmpty)
     val actualStatus: Status = response.get.status
     assert(actualStatus === Status.NotFound)
-    val actualBody: String = response.get.as[String].unsafeRunSync
+    val actualBody: String = response.get.as[String].unsafeRunSync()
     assert(actualBody === "Specified quiz does not exist")
   }
 }

--- a/backend/service-quiz/src/test/scala/pl/smtc/smartwords/database/ModeDatabaseTest.scala
+++ b/backend/service-quiz/src/test/scala/pl/smtc/smartwords/database/ModeDatabaseTest.scala
@@ -1,12 +1,20 @@
 package pl.smtc.smartwords.database
 
+import org.scalatest.BeforeAndAfterAll
 import org.scalatest.funsuite.AnyFunSuite
 import pl.smtc.smartwords.model.Mode
 
 import java.io.File
 import java.nio.file.{Path, Paths}
 
-class ModeDatabaseTest extends AnyFunSuite {
+class ModeDatabaseTest extends AnyFunSuite with BeforeAndAfterAll {
+
+  override def afterAll(): Unit = {
+    for {
+      files <- Option(new File(Paths.get(getClass.getResource("/").toURI).toString).listFiles)
+      file <- files if file.getName.endsWith(".json") && !file.getName.endsWith("test-mode-database-load.json")
+    } file.delete()
+  }
 
   private val resourceDir: Path = Paths.get(getClass.getResource("/").toURI)
   private val databaseTestFile: String = "test-mode-database-crud.json"

--- a/backend/service-word/.idea/scala_compiler.xml
+++ b/backend/service-word/.idea/scala_compiler.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ScalaCompilerConfiguration">
-    <profile name="sbt 1" modules="service-quiz,service-quiz_6096,service-quiz_9211,service-word,service-word_4924,smart-words" />
+    <profile name="sbt" modules="service-word">
+      <option name="deprecationWarnings" value="true" />
+      <option name="featureWarnings" value="true" />
+    </profile>
   </component>
 </project>

--- a/backend/service-word/.idea/scala_compiler.xml
+++ b/backend/service-word/.idea/scala_compiler.xml
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ScalaCompilerConfiguration">
+    <option name="deprecationWarnings" value="true" />
+    <option name="featureWarnings" value="true" />
+    <parameters>
+      <parameter value="-deprecation" />
+    </parameters>
     <profile name="sbt" modules="service-word">
       <option name="deprecationWarnings" value="true" />
       <option name="featureWarnings" value="true" />

--- a/backend/service-word/build.sbt
+++ b/backend/service-word/build.sbt
@@ -20,6 +20,8 @@ libraryDependencies ++= Seq(
   "org.scalatest"   %% "scalatest"           % ScalaTestVersion
 )
 
+scalacOptions ++= Seq("-deprecation", "-feature")
+
 run := Defaults
   .runTask(
     Runtime / fullClasspath,

--- a/backend/service-word/src/main/scala/pl/smtc/smartwords/database/WordDatabase.scala
+++ b/backend/service-word/src/main/scala/pl/smtc/smartwords/database/WordDatabase.scala
@@ -34,7 +34,7 @@ class WordDatabase {
     }
     dictionaryFiles.foreach(file => {
       Using(new BufferedInputStream(new FileInputStream(file))) { fileStream =>
-        val lines = Source.fromInputStream(fileStream).getLines.mkString.stripMargin
+        val lines = Source.fromInputStream(fileStream).getLines().mkString.stripMargin
         decode[List[Word]](lines) match {
           case Right(words) =>
             words.foreach(word => {

--- a/backend/service-word/src/main/scala/pl/smtc/smartwords/model/Dictionary.scala
+++ b/backend/service-word/src/main/scala/pl/smtc/smartwords/model/Dictionary.scala
@@ -62,7 +62,7 @@ object Dictionary {
   private def generateDictionaryFileName(mode: Option[Int], language: String): String = {
     val modeStr = mode match {
       case None => ""
-      case Some(modeValue) => modeValue + "-"
+      case Some(modeValue) => s"$modeValue-"
     }
     val generatedDescription: String = DateTimeFormatter.ofPattern("YYYY-MM-dd").format(LocalDate.now())
     "words-quiz-" + modeStr + language + "@" + generatedDescription + ".json"

--- a/backend/service-word/src/test/scala/pl/smtc/smartwords/controller/DictionaryControllerTest.scala
+++ b/backend/service-word/src/test/scala/pl/smtc/smartwords/controller/DictionaryControllerTest.scala
@@ -43,7 +43,7 @@ class DictionaryControllerTest extends AnyFunSuite with BeforeAndAfterAll {
     val expected: Json = json"""[ { "game" : "quiz", "mode" : 998, "language" : "en" },
                                   { "game" : "quiz", "mode" : 999, "language" : "pl" },
                                   { "game" : "quiz", "mode" : 997, "language" : "de" } ]"""
-    assert(response.get.as[Json].unsafeRunSync === expected)
+    assert(response.get.as[Json].unsafeRunSync() === expected)
   }
 
   private def createTestDatabase(): WordDatabase = {

--- a/backend/service-word/src/test/scala/pl/smtc/smartwords/controller/HealthControllerTest.scala
+++ b/backend/service-word/src/test/scala/pl/smtc/smartwords/controller/HealthControllerTest.scala
@@ -22,7 +22,7 @@ class HealthControllerTest extends AnyFunSuite {
     val response: Option[Response[IO]] = controllerUnderTest.getRoutes.run(request).value.unsafeRunSync()
     val actualStatus: Status = response.get.status
     assert(actualStatus === Status.Ok)
-    assert(response.get.as[String].unsafeRunSync === "Service: WORD - status: OK")
+    assert(response.get.as[String].unsafeRunSync() === "Service: WORD - status: OK")
   }
 
 }

--- a/backend/service-word/src/test/scala/pl/smtc/smartwords/controller/WordControllerTest.scala
+++ b/backend/service-word/src/test/scala/pl/smtc/smartwords/controller/WordControllerTest.scala
@@ -30,7 +30,7 @@ class WordControllerTest extends AnyFunSuite {
     val response: Option[Response[IO]] = controllerUnderTest.getRoutes.run(request).value.unsafeRunSync()
     val actualStatus: Status = response.get.status
     assert(actualStatus === Status.BadRequest)
-    assert(response.get.as[String].unsafeRunSync === "Invalid 'mode' parameter: value '111' is not supported.")
+    assert(response.get.as[String].unsafeRunSync() === "Invalid 'mode' parameter: value '111' is not supported.")
   }
 
   test("testGetRoutesReturnsBadRequestWhenGettingWordsWithNonExistingLanguage") {
@@ -40,7 +40,7 @@ class WordControllerTest extends AnyFunSuite {
     val response: Option[Response[IO]] = controllerUnderTest.getRoutes.run(request).value.unsafeRunSync()
     val actualStatus: Status = response.get.status
     assert(actualStatus === Status.BadRequest)
-    assert(response.get.as[String].unsafeRunSync === "Invalid 'language' parameter: value 'es' is not supported.")
+    assert(response.get.as[String].unsafeRunSync() === "Invalid 'language' parameter: value 'es' is not supported.")
   }
 
   test("testGetRoutesReturnsEmptyResultWhenGettingWordsWithExistingButIncompatibleModeAndLanguage") {
@@ -51,7 +51,7 @@ class WordControllerTest extends AnyFunSuite {
     val actualStatus: Status = response.get.status
     assert(actualStatus === Status.Ok)
     val expected: Json = json"""[]"""
-    assert(response.get.as[Json].unsafeRunSync === expected)
+    assert(response.get.as[Json].unsafeRunSync() === expected)
   }
 
   test("testGetRoutesReturnsCorrectResponseWhenGettingWordsWithExistingModeAndLanguage") {
@@ -64,7 +64,7 @@ class WordControllerTest extends AnyFunSuite {
     val expected: Json = json"""[ { "name" : "word-1-pl", "category" : "verb", "description" : [""] },
                                   { "name" : "word-2-pl", "category" : "latin", "description" : [""] },
                                   { "name" : "word-3-pl", "category" : "latin", "description" : [""] } ]"""
-    assert(response.get.as[Json].unsafeRunSync === expected)
+    assert(response.get.as[Json].unsafeRunSync() === expected)
   }
 
   test("testGetRoutesReturnsCorrectResponseWhenGettingWordsWithCategoryFilter") {
@@ -76,7 +76,7 @@ class WordControllerTest extends AnyFunSuite {
     assert(actualStatus === Status.Ok)
     val expected: Json = json"""[ { "name" : "word-2-pl", "category" : "latin", "description" : [""] },
                                   { "name" : "word-3-pl", "category" : "latin", "description" : [""] } ]"""
-    assert(response.get.as[Json].unsafeRunSync === expected)
+    assert(response.get.as[Json].unsafeRunSync() === expected)
   }
 
   test("testGetRoutesReturnsEmptyResponseWhenGettingWordsWithNotUsedCategoryFilter") {
@@ -87,7 +87,7 @@ class WordControllerTest extends AnyFunSuite {
     val actualStatus: Status = response.get.status
     assert(actualStatus === Status.Ok)
     val expected: Json = json"""[]"""
-    assert(response.get.as[Json].unsafeRunSync === expected)
+    assert(response.get.as[Json].unsafeRunSync() === expected)
   }
 
   test("testGetRoutesReturnsBadRequestWhenGettingWordsWithNotSupportedCategoryFilter") {
@@ -97,7 +97,7 @@ class WordControllerTest extends AnyFunSuite {
     val response: Option[Response[IO]] = controllerUnderTest.getRoutes.run(request).value.unsafeRunSync()
     val actualStatus: Status = response.get.status
     assert(actualStatus === Status.BadRequest)
-    assert(response.get.as[String].unsafeRunSync === "Invalid 'cat' parameter: value 'non-supported' is not supported.")
+    assert(response.get.as[String].unsafeRunSync() === "Invalid 'cat' parameter: value 'non-supported' is not supported.")
   }
 
   test("testGetRoutesReturnsCorrectResponseWhenGettingWordsWithSizeFilter") {
@@ -108,7 +108,7 @@ class WordControllerTest extends AnyFunSuite {
     val actualStatus: Status = response.get.status
     assert(actualStatus === Status.Ok)
     val expected: Json = json"""[ { "name" : "word-1-pl", "category" : "verb", "description" : [""] } ]"""
-    assert(response.get.as[Json].unsafeRunSync === expected)
+    assert(response.get.as[Json].unsafeRunSync() === expected)
   }
 
   test("testGetRoutesReturnsCorrectResponseWhenGettingWordsWithBigSizeFilter") {
@@ -121,7 +121,7 @@ class WordControllerTest extends AnyFunSuite {
     val expected: Json = json"""[ { "name" : "word-1-pl", "category" : "verb", "description" : [""] },
                                   { "name" : "word-2-pl", "category" : "latin", "description" : [""] },
                                   { "name" : "word-3-pl", "category" : "latin", "description" : [""] } ]"""
-    assert(response.get.as[Json].unsafeRunSync === expected)
+    assert(response.get.as[Json].unsafeRunSync() === expected)
   }
 
   test("testGetRoutesReturnsBadRequestWhenGettingWordsWithSizeFilterEqualsZero") {
@@ -131,7 +131,7 @@ class WordControllerTest extends AnyFunSuite {
     val response: Option[Response[IO]] = controllerUnderTest.getRoutes.run(request).value.unsafeRunSync()
     val actualStatus: Status = response.get.status
     assert(actualStatus === Status.BadRequest)
-    assert(response.get.as[String].unsafeRunSync === "Incorrect 'size' parameter value: must be greater then 0.")
+    assert(response.get.as[String].unsafeRunSync() === "Incorrect 'size' parameter value: must be greater then 0.")
   }
 
   test("testGetRoutesReturnsBadRequestWhenGettingWordsWithNegativeSizeFilter") {
@@ -141,7 +141,7 @@ class WordControllerTest extends AnyFunSuite {
     val response: Option[Response[IO]] = controllerUnderTest.getRoutes.run(request).value.unsafeRunSync()
     val actualStatus: Status = response.get.status
     assert(actualStatus === Status.BadRequest)
-    assert(response.get.as[String].unsafeRunSync === "Incorrect 'size' parameter value: must be greater then 0.")
+    assert(response.get.as[String].unsafeRunSync() === "Incorrect 'size' parameter value: must be greater then 0.")
   }
 
   test("testGetRoutesReturnsBadRequestWhenGettingWordsWithNonIntegerSizeFilter") {
@@ -151,7 +151,7 @@ class WordControllerTest extends AnyFunSuite {
     val response: Option[Response[IO]] = controllerUnderTest.getRoutes.run(request).value.unsafeRunSync()
     val actualStatus: Status = response.get.status
     assert(actualStatus === Status.BadRequest)
-    assert(response.get.as[String].unsafeRunSync === "Query decoding Int failed: invalid 'size' parameter value.")
+    assert(response.get.as[String].unsafeRunSync() === "Query decoding Int failed: invalid 'size' parameter value.")
   }
 
   test("testGetRoutesReturnsCorrectResponseWhenGettingWordsWithCategoryAndSizeFilter") {
@@ -162,7 +162,7 @@ class WordControllerTest extends AnyFunSuite {
     val actualStatus: Status = response.get.status
     assert(actualStatus === Status.Ok)
     val expected: Json = json"""[ { "name" : "word-2-pl", "category" : "latin", "description" : [""] } ]"""
-    assert(response.get.as[Json].unsafeRunSync === expected)
+    assert(response.get.as[Json].unsafeRunSync() === expected)
   }
 
   test("testGetRoutesReturnsCorrectResponseWhenGettingWordsWithSizeAndCategoryFilter") {
@@ -173,7 +173,7 @@ class WordControllerTest extends AnyFunSuite {
     val actualStatus: Status = response.get.status
     assert(actualStatus === Status.Ok)
     val expected: Json = json"""[ { "name" : "word-2-pl", "category" : "latin", "description" : [""] } ]"""
-    assert(response.get.as[Json].unsafeRunSync === expected)
+    assert(response.get.as[Json].unsafeRunSync() === expected)
   }
 
   test("testGetRoutesReturnsCorrectResponseWhenGettingWordsRandomFilterOff") {
@@ -185,7 +185,7 @@ class WordControllerTest extends AnyFunSuite {
     assert(actualStatus === Status.Ok)
     val expected: Json = json"""[ { "name" : "word-1-en", "category" : "adjective", "description" : [""] },
                                   { "name" : "word-2-en", "category" : "person", "description" : [""] }]"""
-    assert(response.get.as[Json].unsafeRunSync === expected)
+    assert(response.get.as[Json].unsafeRunSync() === expected)
   }
 
   test("testGetRoutesReturnsCorrectResponseWhenGettingWordsRandomFilterOn") {
@@ -199,7 +199,7 @@ class WordControllerTest extends AnyFunSuite {
                                    { "name" : "word-2-en", "category" : "person", "description" : [""] }]"""
     val sequence2: Json = json"""[ { "name" : "word-2-en", "category" : "person", "description" : [""] },
                                    { "name" : "word-1-en", "category" : "adjective", "description" : [""] }]"""
-    val actual: Json = response.get.as[Json].unsafeRunSync
+    val actual: Json = response.get.as[Json].unsafeRunSync()
     assert(actual === sequence1 || actual === sequence2)
   }
 
@@ -210,7 +210,7 @@ class WordControllerTest extends AnyFunSuite {
     val response: Option[Response[IO]] = controllerUnderTest.getRoutes.run(request).value.unsafeRunSync()
     val actualStatus: Status = response.get.status
     assert(actualStatus === Status.BadRequest)
-    assert(response.get.as[String].unsafeRunSync === "Query decoding Boolean failed: invalid 'random' parameter value.")
+    assert(response.get.as[String].unsafeRunSync() === "Query decoding Boolean failed: invalid 'random' parameter value.")
   }
 
   test("testGetRoutesReturnsCorrectResponseWhenAddingNewWord") {
@@ -222,7 +222,7 @@ class WordControllerTest extends AnyFunSuite {
     assert(response.nonEmpty)
     val actualStatus: Status = response.get.status
     assert(actualStatus === Status.Ok)
-    assert(response.get.as[String].unsafeRunSync === "added word 'word-10-de'")
+    assert(response.get.as[String].unsafeRunSync() === "added word 'word-10-de'")
   }
 
   test("testGetRoutesReturnsFoundWhenAddingExistingWord") {
@@ -234,7 +234,7 @@ class WordControllerTest extends AnyFunSuite {
     assert(response.nonEmpty)
     val actualStatus: Status = response.get.status
     assert(actualStatus === Status.Found)
-    assert(response.get.as[String].unsafeRunSync === "word 'word-1-de' already defined")
+    assert(response.get.as[String].unsafeRunSync() === "word 'word-1-de' already defined")
   }
 
   test("testGetRoutesReturnsBadRequestWhenAddingNewWordWithBadLanguage") {
@@ -246,7 +246,7 @@ class WordControllerTest extends AnyFunSuite {
     assert(response.nonEmpty)
     val actualStatus: Status = response.get.status
     assert(actualStatus === Status.BadRequest)
-    assert(response.get.as[String].unsafeRunSync === "Invalid 'language' parameter: value 'it' is not supported.")
+    assert(response.get.as[String].unsafeRunSync() === "Invalid 'language' parameter: value 'it' is not supported.")
   }
 
   test("testGetRoutesReturnsBadRequestWhenAddingNewWordWithInvalidMode") {
@@ -258,7 +258,7 @@ class WordControllerTest extends AnyFunSuite {
     assert(response.nonEmpty)
     val actualStatus: Status = response.get.status
     assert(actualStatus === Status.BadRequest)
-    assert(response.get.as[String].unsafeRunSync === "Invalid 'mode' parameter: value '23' is not supported.")
+    assert(response.get.as[String].unsafeRunSync() === "Invalid 'mode' parameter: value '23' is not supported.")
   }
 
   test("testGetRoutesReturnsBadRequestWhenAddingNewWordWithNonIntegerMode") {
@@ -270,7 +270,7 @@ class WordControllerTest extends AnyFunSuite {
     assert(response.nonEmpty)
     val actualStatus: Status = response.get.status
     assert(actualStatus === Status.BadRequest)
-    assert(response.get.as[String].unsafeRunSync === "Invalid 'mode' parameter: value 'mode' cannot be parsed.")
+    assert(response.get.as[String].unsafeRunSync() === "Invalid 'mode' parameter: value 'mode' cannot be parsed.")
   }
 
   test("testGetRoutesThrowsExceptionWhenAddingWordWithInvalidJsonBody") {
@@ -290,7 +290,7 @@ class WordControllerTest extends AnyFunSuite {
     assert(response.nonEmpty)
     val actualStatus: Status = response.get.status
     assert(actualStatus === Status.Ok)
-    assert(response.get.as[String].unsafeRunSync === "updated word 'word-1-de'")
+    assert(response.get.as[String].unsafeRunSync() === "updated word 'word-1-de'")
   }
 
   test("testGetRoutesReturnsNotFoundWhenUpdatingNonExistingWord") {
@@ -302,7 +302,7 @@ class WordControllerTest extends AnyFunSuite {
     assert(response.nonEmpty)
     val actualStatus: Status = response.get.status
     assert(actualStatus === Status.NotFound)
-    assert(response.get.as[String].unsafeRunSync === "word 'word-10-de' not found in DB")
+    assert(response.get.as[String].unsafeRunSync() === "word 'word-10-de' not found in DB")
   }
 
   test("testGetRoutesReturnsBadRequestWhenUpdatingExistingWordButWithIncompatibleMode") {
@@ -314,7 +314,7 @@ class WordControllerTest extends AnyFunSuite {
     assert(response.nonEmpty)
     val actualStatus: Status = response.get.status
     assert(actualStatus === Status.NotFound)
-    assert(response.get.as[String].unsafeRunSync === "word 'word-1-de' not found in DB")
+    assert(response.get.as[String].unsafeRunSync() === "word 'word-1-de' not found in DB")
   }
 
   test("testGetRoutesReturnsBadRequestWhenUpdatingExistingWordButWithIncompatibleLanguage") {
@@ -326,7 +326,7 @@ class WordControllerTest extends AnyFunSuite {
     assert(response.nonEmpty)
     val actualStatus: Status = response.get.status
     assert(actualStatus === Status.NotFound)
-    assert(response.get.as[String].unsafeRunSync === "word 'word-1-de' not found in DB")
+    assert(response.get.as[String].unsafeRunSync() === "word 'word-1-de' not found in DB")
   }
 
   test("testGetRoutesReturnsBadRequestWhenUpdatingExistingWordWithBadLanguage") {
@@ -338,7 +338,7 @@ class WordControllerTest extends AnyFunSuite {
     assert(response.nonEmpty)
     val actualStatus: Status = response.get.status
     assert(actualStatus === Status.BadRequest)
-    assert(response.get.as[String].unsafeRunSync === "Invalid 'language' parameter: value 'es' is not supported.")
+    assert(response.get.as[String].unsafeRunSync() === "Invalid 'language' parameter: value 'es' is not supported.")
   }
 
   test("testGetRoutesReturnsBadRequestWhenUpdatingExistingWordWithBadMode") {
@@ -350,7 +350,7 @@ class WordControllerTest extends AnyFunSuite {
     assert(response.nonEmpty)
     val actualStatus: Status = response.get.status
     assert(actualStatus === Status.BadRequest)
-    assert(response.get.as[String].unsafeRunSync === "Invalid 'mode' parameter: value '900' is not supported.")
+    assert(response.get.as[String].unsafeRunSync() === "Invalid 'mode' parameter: value '900' is not supported.")
   }
 
   test("testGetRoutesReturnsBadRequestWhenUpdatingExistingWordWithNonIntegerMode") {
@@ -362,7 +362,7 @@ class WordControllerTest extends AnyFunSuite {
     assert(response.nonEmpty)
     val actualStatus: Status = response.get.status
     assert(actualStatus === Status.BadRequest)
-    assert(response.get.as[String].unsafeRunSync === "Invalid 'mode' parameter: value 'mode' cannot be parsed.")
+    assert(response.get.as[String].unsafeRunSync() === "Invalid 'mode' parameter: value 'mode' cannot be parsed.")
   }
 
   test("testGetRoutesThrowsExceptionWhenUpdatingWordWithInvalidJsonBody") {
@@ -381,7 +381,7 @@ class WordControllerTest extends AnyFunSuite {
     assert(response.nonEmpty)
     val actualStatus: Status = response.get.status
     assert(actualStatus === Status.Ok)
-    assert(response.get.as[String].unsafeRunSync === "removed word 'word-1-de'")
+    assert(response.get.as[String].unsafeRunSync() === "removed word 'word-1-de'")
   }
 
   test("testGetRoutesReturnsNotFoundWhenDeletingNonExistingWord") {
@@ -392,7 +392,7 @@ class WordControllerTest extends AnyFunSuite {
     assert(response.nonEmpty)
     val actualStatus: Status = response.get.status
     assert(actualStatus === Status.NotFound)
-    assert(response.get.as[String].unsafeRunSync === "word 'word-5-de' not found in DB")
+    assert(response.get.as[String].unsafeRunSync() === "word 'word-5-de' not found in DB")
   }
 
   test("testGetRoutesReturnsNotFoundWhenDeletingExistingWordButIncompatibleMode") {
@@ -403,7 +403,7 @@ class WordControllerTest extends AnyFunSuite {
     assert(response.nonEmpty)
     val actualStatus: Status = response.get.status
     assert(actualStatus === Status.NotFound)
-    assert(response.get.as[String].unsafeRunSync === "word 'word-1-de' not found in DB")
+    assert(response.get.as[String].unsafeRunSync() === "word 'word-1-de' not found in DB")
   }
 
   test("testGetRoutesReturnsNotFoundWhenDeletingExistingWordButIncompatibleLanguage") {
@@ -414,7 +414,7 @@ class WordControllerTest extends AnyFunSuite {
     assert(response.nonEmpty)
     val actualStatus: Status = response.get.status
     assert(actualStatus === Status.NotFound)
-    assert(response.get.as[String].unsafeRunSync === "word 'word-1-de' not found in DB")
+    assert(response.get.as[String].unsafeRunSync() === "word 'word-1-de' not found in DB")
   }
 
   test("testGetRoutesReturnsBadRequestWhenDeletingWordWithBadLanguage") {
@@ -425,7 +425,7 @@ class WordControllerTest extends AnyFunSuite {
     assert(response.nonEmpty)
     val actualStatus: Status = response.get.status
     assert(actualStatus === Status.BadRequest)
-    assert(response.get.as[String].unsafeRunSync === "Invalid 'language' parameter: value 'fr' is not supported.")
+    assert(response.get.as[String].unsafeRunSync() === "Invalid 'language' parameter: value 'fr' is not supported.")
   }
 
   test("testGetRoutesReturnsBadRequestWhenDeletingWordWithBadMode") {
@@ -436,7 +436,7 @@ class WordControllerTest extends AnyFunSuite {
     assert(response.nonEmpty)
     val actualStatus: Status = response.get.status
     assert(actualStatus === Status.BadRequest)
-    assert(response.get.as[String].unsafeRunSync === "Invalid 'mode' parameter: value '123' is not supported.")
+    assert(response.get.as[String].unsafeRunSync() === "Invalid 'mode' parameter: value '123' is not supported.")
   }
 
   test("testGetRoutesReturnsBadRequestWhenDeletingWordWithNonIntegerMode") {
@@ -447,7 +447,7 @@ class WordControllerTest extends AnyFunSuite {
     assert(response.nonEmpty)
     val actualStatus: Status = response.get.status
     assert(actualStatus === Status.BadRequest)
-    assert(response.get.as[String].unsafeRunSync === "Invalid 'mode' parameter: value 'mode' cannot be parsed.")
+    assert(response.get.as[String].unsafeRunSync() === "Invalid 'mode' parameter: value 'mode' cannot be parsed.")
   }
 
   private def createTestDatabase(): WordDatabase = {


### PR DESCRIPTION
After adding backend services tests (#64) I've introduced a new errors which are not visible in IDE (IntelliJ) but are notified while building via the sbt. In the mentioned PR I've tried to add appropriate changes to the Scala compiler settings but it did not worked quite well (hence I've added a comment in review).
This patch fixes this and adds "-deprecation" and "-feature" flags to compilation and fixes ALL warnings that were produced after displaying all details.